### PR TITLE
Build should fail if integration tests do not pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,13 @@
                                     <goal>integration-test</goal>
                                 </goals>
                             </execution>
+                            <execution>
+                                <id>verify</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
                         </executions>
                         <configuration>
                             <classesDirectory>${project.build.outputDirectory}</classesDirectory>


### PR DESCRIPTION
In recent [Travis builds](https://travis-ci.com/github/liquibase/liquibase-mongodb), the integration tests are failing but the build still succeeds. 

The maven-failsafe-plugin requires an addition execution phase in order to verify the test results. This change will fail a build when any integration tests fail.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-616) by [Unito](https://www.unito.io/learn-more)
