### PR TITLE
Add missing META-INF files and fix two tests

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/lockservice/MongoLockService.java
+++ b/src/main/java/liquibase/ext/mongodb/lockservice/MongoLockService.java
@@ -83,7 +83,7 @@ public class MongoLockService implements LockService {
 
         if (!hasDatabaseChangeLogLockTable()) {
             try {
-                final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", Scope.getCurrentScope().getDatabase());
+                final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase());
                 executor.comment("Create Database Lock Collection");
 
                 final CreateChangelogLockCollectionStatement createChangeLogLockCollectionStatement =
@@ -149,7 +149,7 @@ public class MongoLockService implements LockService {
     public boolean acquireLock() throws LockException {
 
         try {
-            final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", Scope.getCurrentScope().getDatabase());
+            final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase());
             database.rollback();
             this.init();
 

--- a/src/main/resources/META-INF/services/liquibase.changelog.ChangeLogHistoryService
+++ b/src/main/resources/META-INF/services/liquibase.changelog.ChangeLogHistoryService
@@ -1,0 +1,1 @@
+liquibase.ext.mongodb.changelog.MongoHistoryService

--- a/src/main/resources/META-INF/services/liquibase.database.Database
+++ b/src/main/resources/META-INF/services/liquibase.database.Database
@@ -1,0 +1,1 @@
+liquibase.ext.mongodb.database.MongoLiquibaseDatabase

--- a/src/main/resources/META-INF/services/liquibase.database.DatabaseConnection
+++ b/src/main/resources/META-INF/services/liquibase.database.DatabaseConnection
@@ -1,0 +1,1 @@
+liquibase.ext.mongodb.database.MongoConnection

--- a/src/main/resources/META-INF/services/liquibase.executor.Executor
+++ b/src/main/resources/META-INF/services/liquibase.executor.Executor
@@ -1,0 +1,1 @@
+liquibase.ext.mongodb.executor.MongoExecutor

--- a/src/main/resources/META-INF/services/liquibase.lockservice.LockService
+++ b/src/main/resources/META-INF/services/liquibase.lockservice.LockService
@@ -1,0 +1,1 @@
+liquibase.ext.mongodb.lockservice.MongoLockService

--- a/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -1,0 +1,1 @@
+liquibase.ext.mongodb.executor.MongoSqlGenerator


### PR DESCRIPTION
Since the migration to 4.0, there are additional META-INF files that need to be added. In addition, there are two places in the MongoLockService.java that had a null database object.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-621) by [Unito](https://www.unito.io/learn-more)
