### PR TITLE
Fixes unknown database during update

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/database/MongoClientDriver.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoClientDriver.java
@@ -1,0 +1,43 @@
+package liquibase.ext.mongodb.database;
+
+import java.sql.*;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class MongoClientDriver implements Driver {
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+}

--- a/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
@@ -48,9 +48,11 @@ public class MongoConnection implements DatabaseConnection {
 
     public final String MONGO_CONNECTION_STRING_PATTERN = "%s/%s";
 
-    private final MongoClient con;
-    private final com.mongodb.client.MongoDatabase db;
-    private final ConnectionString connectionString;
+    private MongoClient con;
+    private com.mongodb.client.MongoDatabase db;
+    private ConnectionString connectionString;
+
+    public MongoConnection() { }
 
     public MongoConnection(final String connectionString) {
         this.connectionString = new ConnectionString(connectionString);
@@ -145,13 +147,15 @@ public class MongoConnection implements DatabaseConnection {
 	@Override
 	public int getPriority() {
 		// TODO Auto-generated method stub
-		return 0;
+		return PRIORITY_DEFAULT + 500;
 	}
 
 	@Override
 	public void open(String url, Driver driverObject, Properties driverProperties) throws DatabaseException {
-		// TODO Auto-generated method stub
-		
+        this.connectionString = new ConnectionString(url);
+        this.con = MongoClients.create(this.connectionString);
+        this.db = this.con.getDatabase(Objects.requireNonNull(this.connectionString.getDatabase()))
+                .withCodecRegistry(uuidCodecRegistry());
 	}
 
 }

--- a/src/main/java/liquibase/ext/mongodb/database/MongoLiquibaseDatabase.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoLiquibaseDatabase.java
@@ -481,7 +481,7 @@ public class MongoLiquibaseDatabase extends AbstractJdbcDatabase {
 
     public String getDefaultDriver(String url) {
         if (url.startsWith("mongodb://")) {
-            return "MongoClientDriver";
+            return MongoClientDriver.class.getName();
         }
         return null;
     }

--- a/src/main/java/liquibase/ext/mongodb/executor/MongoExecutor.java
+++ b/src/main/java/liquibase/ext/mongodb/executor/MongoExecutor.java
@@ -194,7 +194,7 @@ public class MongoExecutor extends AbstractExecutor {
 
 	@Override
 	public String getName() {
-		return "mongodb";
+		return "jdbc";
 	}
 
 	@Override


### PR DESCRIPTION
During `liquibase update` the current mongodb ext version will fail with an `unknown database` error. These changes proper implements a custom driver that satisfies liquibase core and allows updates to successfully complete. 