### PR TITLE
Issue-38: Rollback doesn't work with liquibase-mongodb-4.0.0.2 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Liquibase turned to be the most feasible tool to extend as it allows to define c
 
 <a name="release-notes"></a>
 ## Release Notes
-####4.1.2
+
+#### 4.1.2
+* Fixed [Rollback doesn't work with liquibase-mongodb-4.0.0.2 extension](https://github.com/liquibase/liquibase-mongodb/issues/38)
+* Added dropCollection and dropIndex Changes
 * Added NoSql JSON Parser which can pass raw JSON for a property like this:
 ```json 
 {
@@ -46,26 +49,35 @@ liquibase.mongodb.adjustTrackingTablesOnStartup=true
 * Overridden Liquibase table names removed. Now will be used the default ones in Liquibase. If previous releases used then table names should be explicitly passed as parameters.
 Currently, by default as Liquibase default :`DATABASECHANGELOGLOCK, DATABASECHANGELOG`
 Previous releases used by default : `databaseChangeLogLock, databaseChangeLog`
-####4.1.1
+
+#### 4.1.1
 * Support for Liquibase 4.1.1
-####4.1.0
+
+#### 4.1.0
 * Support for Liquibase 4.1.0
-####4.0.0
+
+#### 4.0.0
 * Works with Liquibase v4.0.0
-####3.10.0
+
+#### 3.10.0
 * Support for Liquibase 3.10
-####3.9.0
+
+#### 3.9.0
 * First release
 
 <a name="implemented-changes"></a>
 ## Implemented Changes:
 
-A couple of Changes were implemented until identified that majority of of the operations can be achieved using `db.runCommand()` and `db.adminCommand()`
+A couple of Changes were implemented until identified that majority of the operations can be achieved using `db.runCommand()` and `db.adminCommand()`
 
 * [createCollection](https://docs.mongodb.com/manual/reference/method/db.createCollection/#db.createCollection) - 
 Creates a collection with validator
+* [dropCollection](https://docs.mongodb.com/manual/reference/method/db.collection.drop/#db-collection-drop) - 
+Removes a collection or view from the database
 * [createIndex](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#db.collection.createIndex) - 
 Creates an index for a collection
+* [dropIndex](https://docs.mongodb.com/manual/reference/method/db.collection.dropIndex/#db.collection.dropIndex) - 
+Drops index for a collection by keys
 * [insertMany](https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/#db.collection.insertMany) - 
 Inserts multiple documents into a collection
 * [insertOne](https://docs.mongodb.com/manual/tutorial/insert-documents/#insert-a-single-document) - 
@@ -121,8 +133,8 @@ mvn clean install -Prun-its
 ```java
 public class Application {
     public static void main(String[] args) {
-        MongoLiquibaseDatabase database = (MongoLiquibaseDatabase) DatabaseFactory.getInstance().openDatabase(url, null, null, null, null);;
-        iquibase liquibase = new Liquibase("liquibase/ext/changelog.generic.test.xml", new ClassLoaderResourceAccessor(), database);
+        MongoLiquibaseDatabase database = (MongoLiquibaseDatabase) DatabaseFactory.getInstance().openDatabase(url, null, null, null, null);
+        Liquibase liquibase = new Liquibase("liquibase/ext/changelog.generic.test.xml", new ClassLoaderResourceAccessor(), database);
         liquibase.update("");
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/AdminCommandChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/AdminCommandChange.java
@@ -43,7 +43,7 @@ public class AdminCommandChange extends AbstractMongoChange {
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Admin Command run";
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
@@ -20,6 +20,7 @@ package liquibase.ext.mongodb.change;
  * #L%
  */
 
+import liquibase.change.Change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
@@ -31,9 +32,9 @@ import lombok.Setter;
 
 
 @DatabaseChange(name = "createCollection",
-    description = "Create collection with validation " +
-        "https://docs.mongodb.com/manual/reference/method/db.createCollection/#db.createCollection",
-    priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
+        description = "Create collection with validation " +
+                "https://docs.mongodb.com/manual/reference/method/db.createCollection/#db.createCollection",
+        priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
 @NoArgsConstructor
 @Getter
 @Setter
@@ -44,13 +45,22 @@ public class CreateCollectionChange extends AbstractMongoChange {
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Collection " + getCollectionName() + " created";
     }
 
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
-            new CreateCollectionStatement(collectionName, options)
+                new CreateCollectionStatement(collectionName, options)
+        };
+    }
+
+    @Override
+    protected Change[] createInverses() {
+        final DropCollectionChange inverse = new DropCollectionChange();
+        inverse.setCollectionName(getCollectionName());
+        return new Change[]{
+                inverse
         };
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/CreateIndexChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/CreateIndexChange.java
@@ -20,6 +20,7 @@ package liquibase.ext.mongodb.change;
  * #L%
  */
 
+import liquibase.change.Change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
@@ -44,13 +45,23 @@ public class CreateIndexChange extends AbstractMongoChange {
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Index created for collection " + getCollectionName();
     }
 
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
                 new CreateIndexStatement(collectionName, keys, options)
+        };
+    }
+
+    @Override
+    protected Change[] createInverses() {
+        final DropIndexChange inverse = new DropIndexChange();
+        inverse.setCollectionName(getCollectionName());
+        inverse.setKeys(getKeys());
+        return new Change[]{
+                inverse
         };
     }
 

--- a/src/main/java/liquibase/ext/mongodb/change/DropCollectionChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/DropCollectionChange.java
@@ -23,35 +23,33 @@ package liquibase.ext.mongodb.change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
-import liquibase.ext.mongodb.statement.InsertManyStatement;
+import liquibase.ext.mongodb.statement.DropCollectionStatement;
 import liquibase.statement.SqlStatement;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@DatabaseChange(name = "insertMany",
-        description = "Inserts multiple documents into a collection " +
-                "https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/#db.collection.insertMany",
-        priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
+
+@DatabaseChange(name = "dropCollection",
+    description = "Removes a collection or view from the database " +
+        "https://docs.mongodb.com/manual/reference/method/db.collection.drop/#db-collection-drop",
+    priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
 @NoArgsConstructor
 @Getter
 @Setter
-public class InsertManyChange extends AbstractMongoChange {
+public class DropCollectionChange extends AbstractMongoChange {
 
     private String collectionName;
-    private String documents;
-    private String options;
 
     @Override
     public String getConfirmationMessage() {
-        return "Documents inserted into collection " + getCollectionName();
+        return "Collection " + getCollectionName() + " dropped";
     }
 
     @Override
-    public SqlStatement[] generateStatements(final Database database) {
-
+    public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
-                new InsertManyStatement(collectionName, documents, options)
+            new DropCollectionStatement(collectionName)
         };
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/DropIndexChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/DropIndexChange.java
@@ -4,7 +4,7 @@ package liquibase.ext.mongodb.change;
  * #%L
  * Liquibase MongoDB Extension
  * %%
- * Copyright (C) 2019 Mastercard
+ * Copyright (C) 2020 Mastercard
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -23,35 +23,34 @@ package liquibase.ext.mongodb.change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
-import liquibase.ext.mongodb.statement.InsertManyStatement;
+import liquibase.ext.mongodb.statement.DropIndexStatement;
 import liquibase.statement.SqlStatement;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@DatabaseChange(name = "insertMany",
-        description = "Inserts multiple documents into a collection " +
-                "https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/#db.collection.insertMany",
-        priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
+@DatabaseChange(name = "dropIndex",
+        description = "Drops index for a collection by keys" +
+                "https://docs.mongodb.com/manual/reference/method/db.collection.dropIndex/#db.collection.dropIndex",
+        priority = ChangeMetaData.PRIORITY_DATABASE, appliesTo = "collection")
 @NoArgsConstructor
 @Getter
 @Setter
-public class InsertManyChange extends AbstractMongoChange {
+public class DropIndexChange extends AbstractMongoChange {
 
     private String collectionName;
-    private String documents;
-    private String options;
+    private String keys;
 
     @Override
     public String getConfirmationMessage() {
-        return "Documents inserted into collection " + getCollectionName();
+        return "Index dropped for collection " + getCollectionName();
     }
 
     @Override
-    public SqlStatement[] generateStatements(final Database database) {
-
+    public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
-                new InsertManyStatement(collectionName, documents, options)
+                new DropIndexStatement(collectionName, keys)
         };
     }
+
 }

--- a/src/main/java/liquibase/ext/mongodb/change/InsertOneChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/InsertOneChange.java
@@ -44,7 +44,7 @@ public class InsertOneChange extends AbstractMongoChange {
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Document inserted into collection " + getCollectionName();
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/change/RunCommandChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/RunCommandChange.java
@@ -43,7 +43,7 @@ public class RunCommandChange extends AbstractMongoChange {
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        return "Command run";
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/statement/DropIndexStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/DropIndexStatement.java
@@ -1,0 +1,72 @@
+package liquibase.ext.mongodb.statement;
+
+/*-
+ * #%L
+ * Liquibase MongoDB Extension
+ * %%
+ * Copyright (C) 2020 Mastercard
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import liquibase.ext.mongodb.database.MongoConnection;
+import liquibase.nosql.statement.NoSqlExecuteStatement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.bson.Document;
+
+import static java.util.Optional.ofNullable;
+import static liquibase.ext.mongodb.statement.BsonUtils.orEmptyDocument;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class DropIndexStatement extends AbstractCollectionStatement
+        implements NoSqlExecuteStatement<MongoConnection> {
+
+    public static final String COMMAND_NAME = "dropIndex";
+
+    private final Document keys;
+
+    public DropIndexStatement(final String collectionName, final Document keys) {
+        super(collectionName);
+        this.keys = keys;
+    }
+
+    public DropIndexStatement(final String collectionName, final String keys) {
+        this(collectionName, orEmptyDocument(keys));
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public String toJs() {
+        return
+                "db."
+                        + getCollectionName()
+                        + ". "
+                        + getCommandName()
+                        + "("
+                        + ofNullable(keys).map(Document::toJson).orElse(null)
+                        + ");";
+    }
+
+    @Override
+    public void execute(final MongoConnection connection) {
+        connection.getDatabase().getCollection(collectionName).dropIndex(keys);
+    }
+
+}

--- a/src/main/java/liquibase/nosql/database/AbstractNoSqlDatabase.java
+++ b/src/main/java/liquibase/nosql/database/AbstractNoSqlDatabase.java
@@ -218,26 +218,6 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
     }
 
     @Override
-    public void saveStatements(final Change change, final List<SqlVisitor> sqlVisitors, final Writer writer) throws IOException {
-        //TODO: implementation
-    }
-
-    @Override
-    public void executeRollbackStatements(final Change change, final List<SqlVisitor> sqlVisitors) throws LiquibaseException {
-        //TODO: implementation
-    }
-
-    @Override
-    public void executeRollbackStatements(final SqlStatement[] statements, final List<SqlVisitor> sqlVisitors) throws LiquibaseException {
-        //TODO: implementation
-    }
-
-    @Override
-    public void saveRollbackStatement(final Change change, final List<SqlVisitor> sqlVisitors, final Writer writer) throws IOException, LiquibaseException {
-        //TODO: implementation
-    }
-
-    @Override
     public List<DatabaseFunction> getDateFunctions() {
         //TODO: proper implementation
         return Collections.emptyList();

--- a/src/main/resources/META-INF/services/liquibase.change.Change
+++ b/src/main/resources/META-INF/services/liquibase.change.Change
@@ -1,6 +1,8 @@
 liquibase.ext.mongodb.change.AdminCommandChange
 liquibase.ext.mongodb.change.CreateCollectionChange
+liquibase.ext.mongodb.change.DropCollectionChange
 liquibase.ext.mongodb.change.CreateIndexChange
+liquibase.ext.mongodb.change.DropIndexChange
 liquibase.ext.mongodb.change.InsertManyChange
 liquibase.ext.mongodb.change.InsertOneChange
 liquibase.ext.mongodb.change.RunCommandChange

--- a/src/main/resources/liquibase.parser.core.xml/dbchangelog-ext.xsd
+++ b/src/main/resources/liquibase.parser.core.xml/dbchangelog-ext.xsd
@@ -49,6 +49,16 @@
 
     </xsd:element>
 
+    <xsd:element name="dropCollection">
+
+        <xsd:complexType>
+
+            <xsd:attribute name="collectionName" type="xsd:string" use="required"/>
+
+        </xsd:complexType>
+
+    </xsd:element>
+
     <xsd:element name="createIndex">
 
         <xsd:complexType>
@@ -56,6 +66,20 @@
             <xsd:sequence>
                 <xsd:element name="keys" type="xsd:string" minOccurs="1" maxOccurs="1"/>
                 <xsd:element name="options" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+
+            <xsd:attribute name="collectionName" type="xsd:string" use="required"/>
+
+        </xsd:complexType>
+
+    </xsd:element>
+
+    <xsd:element name="dropIndex">
+
+        <xsd:complexType>
+
+            <xsd:sequence>
+                <xsd:element name="keys" type="xsd:string" minOccurs="1" maxOccurs="1"/>
             </xsd:sequence>
 
             <xsd:attribute name="collectionName" type="xsd:string" use="required"/>

--- a/src/test/java/liquibase/ext/MongoLiquibaseJsonIT.java
+++ b/src/test/java/liquibase/ext/MongoLiquibaseJsonIT.java
@@ -55,6 +55,46 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
     @SneakyThrows
     @Test
     void testMongoLiquibase() {
+        Liquibase liquiBase = new Liquibase("liquibase/ext/json/generic-1-insert-people.json", new ClassLoaderResourceAccessor(), database);
+        liquiBase.update("");
+
+        final List<MongoRanChangeSet> changeSets = findAll.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(2)
+                .filteredOn(c -> c.getId().equals("1")).hasSize(1).first()
+                .returns("liquibase/ext/json/generic-1-insert-people.json", RanChangeSet::getChangeLog)
+                .returns("Alex", RanChangeSet::getAuthor)
+                .returns(CheckSum.parse("8:6b06a10d8faf0a516c7f4a77f76041f2"), RanChangeSet::getLastCheckSum)
+                .returns(true, c -> nonNull(c.getDateExecuted()))
+                .returns(null, RanChangeSet::getTag)
+                .returns(ChangeSet.ExecType.EXECUTED, RanChangeSet::getExecType)
+                .returns("createCollection collectionName=person", RanChangeSet::getDescription)
+                .returns("Create person collection", RanChangeSet::getComments)
+                .returns(true, c -> c.getContextExpression().isEmpty())
+                .returns(true, c -> c.getLabels().isEmpty())
+                .returns(true, c -> c.getDeploymentId().matches("^[0-9]{10}$"))
+                .returns(1, RanChangeSet::getOrderExecuted)
+                .returns(LiquibaseUtil.getBuildVersion(), RanChangeSet::getLiquibaseVersion);
+
+        assertThat(changeSets)
+                .filteredOn(c -> c.getId().equals("2")).hasSize(1).first()
+                .returns("liquibase/ext/json/generic-1-insert-people.json", RanChangeSet::getChangeLog)
+                .returns("Nick", RanChangeSet::getAuthor)
+                .returns(CheckSum.parse("8:3da23c9b02c5297da06ca10d41c783aa"), RanChangeSet::getLastCheckSum)
+                .returns(true, c -> nonNull(c.getDateExecuted()))
+                .returns(null, RanChangeSet::getTag)
+                .returns(ChangeSet.ExecType.EXECUTED, RanChangeSet::getExecType)
+                .returns("insertOne collectionName=person; insertMany collectionName=person", RanChangeSet::getDescription)
+                .returns("Populate person table", RanChangeSet::getComments)
+                .returns(true, c -> c.getContextExpression().isEmpty())
+                .returns(true, c -> c.getLabels().isEmpty())
+                .returns(true, c -> c.getDeploymentId().matches("^[0-9]{10}$"))
+                .returns(2, RanChangeSet::getOrderExecuted)
+                .returns(LiquibaseUtil.getBuildVersion(), RanChangeSet::getLiquibaseVersion);
+    }
+
+    @SneakyThrows
+    @Test
+    void testMongoParentFile() {
         Liquibase liquiBase = new Liquibase("liquibase/ext/json/generic-0-main-1.json", new ClassLoaderResourceAccessor(), database);
         liquiBase.update("");
 

--- a/src/test/java/liquibase/ext/mongodb/TestUtils.java
+++ b/src/test/java/liquibase/ext/mongodb/TestUtils.java
@@ -30,7 +30,6 @@ import liquibase.ext.mongodb.database.MongoLiquibaseDatabase;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.util.file.FilenameUtils;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import org.bson.Document;
@@ -53,7 +52,7 @@ public final class TestUtils {
     public static final String PROPERTY_FILE = "application-test.properties";
     private static final String CMD_DROP_ALL_ROLES = "{dropAllRolesFromDatabase: 1, writeConcern: { w: \"majority\" }}";
     private static final String CMD_DROP_ALL_USERS = "{dropAllUsersFromDatabase: 1, writeConcern: { w: \"majority\" }}";
-    private static final String CMD_GET_ALL_ROLES = "{getAllRolesFromDatabase: 1,  showPrivileges:false, showBuiltinRoles: false }}";
+    //private static final String CMD_GET_ALL_ROLES = "{getAllRolesFromDatabase: 1,  showPrivileges:false, showBuiltinRoles: false }}";
 
     public static List<String> getCollections(final MongoConnection connection) {
         return StreamSupport.stream(connection.getDatabase().listCollectionNames().spliterator(), false)
@@ -77,7 +76,7 @@ public final class TestUtils {
     }
 
     public static List<Document> getAllRoles(final MongoConnection connection) {
-        return (List<Document>) connection.getDatabase()
+        return connection.getDatabase()
             .runCommand(Document.parse("{ rolesInfo: 1, showPrivileges:false, showBuiltinRoles: false }"))
             .getList("roles", Document.class);
     }

--- a/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
@@ -36,7 +36,7 @@ class AdminCommandChangeTest extends AbstractMongoChangeTest {
 
     @Test
     void getConfirmationMessage() {
-        assertThat(new AdminCommandChange().getConfirmationMessage()).isNull();
+        assertThat(new AdminCommandChange().getConfirmationMessage()).isEqualTo("Admin Command run");
     }
 
     @Test
@@ -44,7 +44,8 @@ class AdminCommandChangeTest extends AbstractMongoChangeTest {
     void generateStatements() {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.admin-command.test.xml", database);
 
-        assertThat(changeSets).hasSize(1);
+        assertThat(changeSets).hasSize(1).first()
+                .returns("8:e17342ecb217a7588eb1d33af4fadff4",  s -> s.generateCheckSum().toString());
 
         assertThat(changeSets.get(0).getChanges())
             .hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/InsertManyChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertManyChangeTest.java
@@ -33,7 +33,9 @@ class InsertManyChangeTest extends AbstractMongoChangeTest {
 
     @Test
     void getConfirmationMessage() {
-        assertThat(new InsertManyChange().getConfirmationMessage()).isNull();
+        final InsertManyChange insertManyChange = new InsertManyChange();
+        insertManyChange.setCollectionName("collection1");
+        assertThat(insertManyChange.getConfirmationMessage()).isEqualTo("Documents inserted into collection collection1");
     }
 
     @Test
@@ -41,14 +43,18 @@ class InsertManyChangeTest extends AbstractMongoChangeTest {
     void generateStatements() {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.insert-many.test.xml", database);
 
-        assertThat(changeSets).hasSize(1);
+        assertThat(changeSets)
+                .hasSize(1).first()
+                .returns("8:c60b95277dcdd83dd5833268fb76d12b",  s -> s.generateCheckSum().toString());
+
         assertThat(changeSets.get(0).getChanges())
-            .hasSize(1)
-            .hasOnlyElementsOfType(InsertManyChange.class);
+                .hasSize(1)
+                .hasOnlyElementsOfType(InsertManyChange.class);
+
         assertThat(changeSets.get(0).getChanges().get(0))
-            .hasFieldOrPropertyWithValue("collectionName", "insertManyTest1")
-            .hasFieldOrPropertyWithValue("documents", "[\n                { id: 2 },\n                { id: 3,\n                  "
-                + "address: { nr: 1, ap: 5}\n                }\n                ]")
-            .hasFieldOrPropertyWithValue("options", null);
+                .hasFieldOrPropertyWithValue("collectionName", "insertManyTest1")
+                .hasFieldOrPropertyWithValue("documents", "[\n                { id: 2 },\n                { id: 3,\n                  "
+                        + "address: { nr: 1, ap: 5}\n                }\n                ]")
+                .hasFieldOrPropertyWithValue("options", null);
     }
 }

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -33,7 +33,9 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
 
     @Test
     void getConfirmationMessage() {
-        assertThat(new InsertOneChange().getConfirmationMessage()).isNull();
+        final InsertOneChange insertOneChange = new InsertOneChange();
+        insertOneChange.setCollectionName("collection1");
+        assertThat(insertOneChange.getConfirmationMessage()).isEqualTo("Document inserted into collection collection1");
     }
 
     @Test
@@ -52,11 +54,13 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasSize(2)
             .hasOnlyElementsOfType(InsertOneChange.class);
 
+        assertThat(changeSets.get(0)).returns("8:4e072f0d1a237e4e98b5edac60c3f335", s -> s.generateCheckSum().toString());
         assertThat(changeSets.get(0).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest1")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 111\n                }")
             .hasFieldOrPropertyWithValue("options", null);
 
+        assertThat(changeSets.get(1)).returns("8:e504f1757d0460c82b54b702794b8cf7",  s -> s.generateCheckSum().toString());
         assertThat(changeSets.get(1).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest2")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 2\n                }")
@@ -67,6 +71,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasFieldOrPropertyWithValue("document", "{\n                id: 3\n                }")
             .hasFieldOrPropertyWithValue("options", null);
 
+        assertThat(changeSets.get(2)).returns("8:4eff4f9e1b017ccce8da57f3c8125f13",  s -> s.generateCheckSum().toString());
         assertThat(changeSets.get(2).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest2")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 21323123\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
@@ -37,7 +37,7 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
 
     @Test
     void getConfirmationMessage() {
-        assertThat(new RunCommandChange().getConfirmationMessage()).isNull();
+        assertThat(new RunCommandChange().getConfirmationMessage()).isEqualTo("Command run");
     }
 
     @SneakyThrows
@@ -46,6 +46,8 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.run-command.test.xml", database);
 
         assertThat(changeSets).hasSize(2);
+
+        assertThat(changeSets.get(0)).returns("8:a9f789a8482003bb149da01cdab92707",  s -> s.generateCheckSum().toString());
 
         assertThat(changeSets.get(0).getChanges()).hasSize(1);
         assertThat(changeSets.get(0).getChanges()).hasOnlyElementsOfTypes(RunCommandChange.class);
@@ -58,6 +60,7 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
         assertThat(sqlStatements).hasOnlyElementsOfType(RunCommandStatement.class);
         assertThat(((RunCommandStatement) sqlStatements[0]).getCommand()).containsEntry("buildInfo", 1);
 
+        assertThat(changeSets.get(1)).returns("8:e17342ecb217a7588eb1d33af4fadff4",  s -> s.generateCheckSum().toString());
         assertThat(changeSets.get(1).getChanges()).hasSize(1);
         assertThat(changeSets.get(1).getChanges()).hasOnlyElementsOfTypes(AdminCommandChange.class);
 

--- a/src/test/resources/liquibase/ext/changelog.implicit-rollback.test.xml
+++ b/src/test/resources/liquibase/ext/changelog.implicit-rollback.test.xml
@@ -1,0 +1,49 @@
+<!--
+  #%L
+  Liquibase MongoDB Extension
+  %%
+  Copyright (C) 2020 Mastercard
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="1" author="alex">
+        <ext:createCollection collectionName="collection1"/>
+        <ext:createCollection collectionName="collection2"/>
+    </changeSet>
+
+    <changeSet id="2" author="alex">
+        <ext:createIndex collectionName="collection1">
+            <ext:keys>
+                { id: 1, type: 1}
+            </ext:keys>
+            <ext:options>
+                {unique: true, name: "ui_namedIndex"}
+            </ext:options>
+        </ext:createIndex>
+
+        <ext:createIndex collectionName="collection2">
+            <ext:keys>
+                { id: 1, type: 1}
+            </ext:keys>
+        </ext:createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/liquibase/ext/changelog.rollback-insert-many.test.xml
+++ b/src/test/resources/liquibase/ext/changelog.rollback-insert-many.test.xml
@@ -1,0 +1,85 @@
+<!--
+  #%L
+  Liquibase MongoDB Extension
+  %%
+  Copyright (C) 2020 Mastercard
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="1" author="alex">
+
+        <ext:insertMany collectionName="insertManyRollback1">
+            <ext:documents>
+                <!--@formatter:off-->
+                [
+                    { id: 1 },
+                    { id: 2 },
+                    { id: 3 }
+                ]
+                <!--@formatter:on-->
+            </ext:documents>
+        </ext:insertMany>
+
+        <rollback>
+            <ext:runCommand>
+                <ext:command>
+                    <!--@formatter:off-->
+                    {
+                        delete: "insertManyRollback1",
+                        deletes: [{q: {id : {$lt: 4}}, limit: 0}]
+                    }
+                    <!--@formatter:on-->
+                </ext:command>
+            </ext:runCommand>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="2" author="alex">
+
+        <ext:insertMany collectionName="insertManyRollback1">
+            <ext:documents>
+                <!--@formatter:off-->
+                [
+                    { id: 4 },
+                    { id: 5 },
+                    { id: 6 }
+                ]
+                <!--@formatter:on-->
+            </ext:documents>
+        </ext:insertMany>
+
+        <rollback>
+            <ext:runCommand>
+                <ext:command>
+                    <!--@formatter:off-->
+                    {
+                        delete: "insertManyRollback1",
+                        deletes: [{q: {id : {$gt: 3}}, limit: 0}]
+                    }
+                    <!--@formatter:on-->
+                </ext:command>
+            </ext:runCommand>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Fix #38
Fixed Explicit Rollback 
Added Implicit Rollbacks for createCollection and createIndex with respective dropCollection and dropIndex Inverses



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-897) by [Unito](https://www.unito.io/learn-more)
