### PR TITLE
Issue-53: Pre-released 4.1.2-SNAPSHOT.jar JSON Format update fails on insertMany

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ mongo-java-driver:3.12.7
 
 ### Adjust connection string
  
-Connection url can be adjusted here: [`db.connection.uri`](./src/test/resources/application-test.properties)
+Connection url can be adjusted here: [`url`](./src/test/resources/liquibase.properties)
 Run Integration tests by enabling `run-its` profile 
 
 ### Run integration tests

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson-core.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-core.version}</version>
             <scope>compile</scope>

--- a/src/main/java/liquibase/ext/mongodb/change/AbstractMongoChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/AbstractMongoChange.java
@@ -30,4 +30,14 @@ public abstract class AbstractMongoChange extends AbstractChange {
     public boolean supports(Database database) {
         return database instanceof MongoLiquibaseDatabase;
     }
+
+    @Override
+    public boolean generateStatementsVolatile(final Database database) {
+        return false;
+    }
+
+    @Override
+    public boolean generateRollbackStatementsVolatile(final Database database) {
+        return false;
+    }
 }

--- a/src/main/java/liquibase/ext/mongodb/database/MongoLiquibaseDatabase.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoLiquibaseDatabase.java
@@ -88,6 +88,15 @@ public class MongoLiquibaseDatabase extends AbstractNoSqlDatabase {
         return MONGODB_PRODUCT_NAME;
     }
 
+    @Override
+    public String getSystemSchema() {
+        return "admin";
+    }
+
+    /*********************************
+     * Custom Parameters
+     *********************************/
+
     public Boolean getAdjustTrackingTablesOnStartup() {
 
         if (adjustTrackingTablesOnStartup != null) {
@@ -106,4 +115,6 @@ public class MongoLiquibaseDatabase extends AbstractNoSqlDatabase {
         return LiquibaseConfiguration.getInstance().getConfiguration(MongoConfiguration.class)
                 .getSupportsValidator();
     }
+
+
 }

--- a/src/main/java/liquibase/nosql/database/AbstractNoSqlDatabase.java
+++ b/src/main/java/liquibase/nosql/database/AbstractNoSqlDatabase.java
@@ -21,22 +21,16 @@ package liquibase.nosql.database;
  */
 
 import liquibase.CatalogAndSchema;
-import liquibase.change.Change;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
-import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.ValidationErrors;
-import liquibase.sql.visitor.SqlVisitor;
 import liquibase.statement.DatabaseFunction;
-import liquibase.statement.SqlStatement;
 import liquibase.structure.DatabaseObject;
 import lombok.NoArgsConstructor;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
@@ -134,11 +128,6 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
     }
 
     @Override
-    public String escapeColumnName(final String catalogName, final String schemaName, final String tableName, final String columnName, final boolean quoteNamesThatMayBeFunctions) {
-        return null;
-    }
-
-    @Override
     public String escapeColumnNameList(final String columnNames) {
         return null;
     }
@@ -150,7 +139,7 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
 
     @Override
     public boolean supportsCatalogs() {
-        return false;
+        return true;
     }
 
     @Override
@@ -212,12 +201,6 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
     }
 
     @Override
-    public boolean isSafeToRunUpdate() throws DatabaseException {
-        //TODO: Add the check to not be admin, etc.
-        return false;
-    }
-
-    @Override
     public List<DatabaseFunction> getDateFunctions() {
         //TODO: proper implementation
         return Collections.emptyList();
@@ -249,11 +232,6 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
     }
 
     @Override
-    public String correctObjectName(final String name, final Class<? extends DatabaseObject> objectType) {
-        return null;
-    }
-
-    @Override
     public boolean isFunction(String string) {
         return false;
     }
@@ -261,11 +239,6 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
     @Override
     public int getDataTypeMaxParameters(String dataTypeName) {
         return 0;
-    }
-
-    @Override
-    public CatalogAndSchema getDefaultSchema() {
-        return null;
     }
 
     @Override
@@ -279,49 +252,9 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
     }
 
     @Override
-    public ObjectQuotingStrategy getObjectQuotingStrategy() {
-        return null;
-    }
-
-    @Override
-    public void setObjectQuotingStrategy(final ObjectQuotingStrategy quotingStrategy) {
-        //TODO: implementation
-    }
-
-    @Override
     public boolean createsIndexesForForeignKeys() {
         //Not applicable
         return false;
-    }
-
-    @Override
-    public boolean getOutputDefaultSchema() {
-        return false;
-    }
-
-    @Override
-    public void setOutputDefaultSchema(final boolean outputDefaultSchema) {
-        //TODO: implementation
-    }
-
-    @Override
-    public boolean isDefaultSchema(final String catalog, final String schema) {
-        return false;
-    }
-
-    @Override
-    public boolean isDefaultCatalog(final String catalog) {
-        return false;
-    }
-
-    @Override
-    public boolean getOutputDefaultCatalog() {
-        return false;
-    }
-
-    @Override
-    public void setOutputDefaultCatalog(final boolean outputDefaultCatalog) {
-        //TODO: implementation
     }
 
     @Override

--- a/src/main/java/liquibase/nosql/lockservice/AbstractNoSqlLockService.java
+++ b/src/main/java/liquibase/nosql/lockservice/AbstractNoSqlLockService.java
@@ -183,7 +183,7 @@ public abstract class AbstractNoSqlLockService implements LockService {
         } finally {
             try {
                 database.rollback();
-            } catch (DatabaseException e) {
+            } catch (final DatabaseException e) {
                 getLogger().severe("Error on acquire change log lock Rollback.", e);
             }
         }

--- a/src/main/java/liquibase/nosql/parser/json/JsonNoSqlChangeLogParser.java
+++ b/src/main/java/liquibase/nosql/parser/json/JsonNoSqlChangeLogParser.java
@@ -15,7 +15,6 @@ import liquibase.Scope;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
-import liquibase.exception.LiquibaseException;
 import liquibase.logging.Logger;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.core.ParsedNode;
@@ -147,7 +146,7 @@ public class JsonNoSqlChangeLogParser implements ChangeLogParser {
         }
     }
 
-    private void loadChangeLogParametersFromFile(ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor, DatabaseChangeLog changeLog, JsonNode property, ContextExpression context, Labels labels, Boolean global) throws IOException, LiquibaseException {
+    private void loadChangeLogParametersFromFile(ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor, DatabaseChangeLog changeLog, JsonNode property, ContextExpression context, Labels labels, Boolean global) throws IOException {
         Properties props = new Properties();
         try (
                 InputStream propertiesStream = resourceAccessor.openStream(null, property.get("file").asText())) {

--- a/src/test/java/liquibase/ext/mongodb/TestUtils.java
+++ b/src/test/java/liquibase/ext/mongodb/TestUtils.java
@@ -48,8 +48,8 @@ public final class TestUtils {
     public static final String EMPTY_STRING = "";
     public static final String EMPTY_OPTION = EMPTY_STRING;
     public static final String OPTION_1 = "{\"opt1\":\"option 1\"}";
-    public static final String DB_CONNECTION_PATH = "db.connection.uri";
-    public static final String PROPERTY_FILE = "application-test.properties";
+    public static final String DB_CONNECTION_PATH = "url";
+    public static final String PROPERTY_FILE = "liquibase.properties";
     private static final String CMD_DROP_ALL_ROLES = "{dropAllRolesFromDatabase: 1, writeConcern: { w: \"majority\" }}";
     private static final String CMD_DROP_ALL_USERS = "{dropAllUsersFromDatabase: 1, writeConcern: { w: \"majority\" }}";
     //private static final String CMD_GET_ALL_ROLES = "{getAllRolesFromDatabase: 1,  showPrivileges:false, showBuiltinRoles: false }}";

--- a/src/test/resources/liquibase.properties
+++ b/src/test/resources/liquibase.properties
@@ -1,0 +1,78 @@
+####     _     _             _ _
+##      | |   (_)           (_) |
+##      | |    _  __ _ _   _ _| |__   __ _ ___  ___
+##      | |   | |/ _` | | | | | '_ \ / _` / __|/ _ \
+##      | |___| | (_| | |_| | | |_) | (_| \__ \  __/
+##      \_____/_|\__, |\__,_|_|_.__/ \__,_|___/\___|
+##                  | |
+##                  |_|
+##
+##      The liquibase.properties file stores properties which do not change often,
+##      such as database connection information. Properties stored here save time
+##      and reduce risk of mistyped command line arguments.
+##      Learn more: https://www.liquibase.org/documentation/config_properties.html
+####
+####
+##   Note about relative and absolute paths:
+##      The liquibase.properties file requires paths for some properties.
+##      The classpath is the path/to/resources (ex. src/main/resources).
+##      The changeLogFile path is relative to the classpath.
+##      The url H2 example below is relative to 'pwd' resource.
+####
+# Enter the path for your changelog file.
+changeLogFile=generic-1-insert-people.json
+
+#### Enter the Target database 'url' information  ####
+url=mongodb://localhost:27017/test_db?socketTimeoutMS=1000&connectTimeoutMS=1000&serverSelectionTimeoutMS=1000
+
+# Enter the username for your Target database.
+#username: dbuser
+
+# Enter the password for your Target database.
+#password: letmein
+
+#### Enter the Source Database 'referenceUrl' information ####
+## The source database is the baseline or reference against which your target database is compared for diff/diffchangelog commands.
+
+# Enter URL for the source database
+#referenceUrl: jdbc:h2:tcp://localhost:9090/mem:integration
+
+# Enter the username for your source database
+#referenceUsername: dbuser
+
+# Enter the password for your source database
+#referencePassword: letmein
+
+#### Liquibase Pro Key Information ####
+# Enter your Liquibase Pro key here.
+# If you don't have one, visit https://download.liquibase.org/liquibase-pro-trial-request-form/ to start a free trial!
+# liquibaseProLicenseKey:
+
+# Logging Configuration
+# logLevel controls the amount of logging information generated. If not set, the default logLevel is INFO.
+# Valid values, from least amount of logging to most, are:
+#   OFF, ERROR, WARN, INFO, DEBUG, TRACE, ALL
+# If you are having problems, setting the logLevel to DEBUG and re-running the command can be helpful.
+logLevel: DEBUG
+
+# The logFile property controls where logging messages are sent. If this is not set, then logging messages are
+# displayed on the console. If this is set, then messages will be sent to a file with the given name.
+# logFile: liquibase.log
+
+
+
+#### Liquibase Hub Information ####
+### Liquibase Hub is a free secure SaaS portal providing status reporting, monitoring & insights
+### into your Liquibase database release automation.
+### https://hub.liquibase.com
+
+## Add your free Hub API key here
+# liquibase.hub.apikey:
+# liquibase.hub.mode:all
+
+
+
+
+##  Get documentation at docs.liquibase.com       ##
+##  Get certified courses at learn.liquibase.com  ##
+##  Get support at liquibase.com/support         ##


### PR DESCRIPTION
Fix #53 
Route Cause is missing jackson libraries in liquibase/lib. 
In this PR just added the liquibase.properties and made dropAll work from CLI by default without specifying schemas. 
Fixed WARNING The following SQL may change each run and therefore is possibly ...



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-901) by [Unito](https://www.unito.io/learn-more)
