### PR TITLE
Add support for all available options for CreateCollectionChange

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
@@ -32,7 +32,7 @@ import lombok.Setter;
 
 
 @DatabaseChange(name = "createCollection",
-        description = "Create collection with validation " +
+        description = "Create collection. Supports all options available: " +
                 "https://docs.mongodb.com/manual/reference/method/db.createCollection/#db.createCollection",
         priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
 @NoArgsConstructor

--- a/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
@@ -33,7 +33,8 @@ import lombok.Setter;
 
 @DatabaseChange(name = "createCollection",
         description = "Create collection. Supports all options available: " +
-                "https://docs.mongodb.com/manual/reference/method/db.createCollection/#db.createCollection",
+                "https://docs.mongodb.com/manual/reference/method/db.createCollection/#db.createCollection\n" +
+                "https://docs.mongodb.com/manual/reference/method/db.runCommand/#db.runCommand",
         priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "collection")
 @NoArgsConstructor
 @Getter

--- a/src/main/java/liquibase/ext/mongodb/changelog/AdjustChangeLogCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/changelog/AdjustChangeLogCollectionStatement.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.lang.Boolean.TRUE;
+import static java.util.Optional.ofNullable;
 
 public class AdjustChangeLogCollectionStatement extends RunCommandStatement {
 
@@ -86,5 +87,19 @@ public class AdjustChangeLogCollectionStatement extends RunCommandStatement {
 
             collection.createIndex(keys, options);
         }
+    }
+
+    @Override
+    public String toJs() {
+        return SHELL_DB_PREFIX
+                        + getCommandName()
+                        + "("
+                        + ofNullable(command).map(Document::toJson).orElse(null)
+                        + ");";
+    }
+
+    @Override
+    public Document run(final MongoConnection connection) {
+        return connection.getDatabase().runCommand(command);
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/lockservice/AdjustChangeLogLockCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/lockservice/AdjustChangeLogLockCollectionStatement.java
@@ -23,8 +23,10 @@ package liquibase.ext.mongodb.lockservice;
 import liquibase.ext.mongodb.database.MongoConnection;
 import liquibase.ext.mongodb.statement.RunCommandStatement;
 import lombok.Getter;
+import org.bson.Document;
 
 import static java.lang.Boolean.TRUE;
+import static java.util.Optional.ofNullable;
 
 public class AdjustChangeLogLockCollectionStatement extends RunCommandStatement {
 
@@ -58,5 +60,19 @@ public class AdjustChangeLogLockCollectionStatement extends RunCommandStatement 
         if(TRUE.equals(supportsValidator)) {
             super.execute(connection);
         }
+    }
+
+    @Override
+    public String toJs() {
+        return SHELL_DB_PREFIX
+                        + getCommandName()
+                        + "("
+                        + ofNullable(command).map(Document::toJson).orElse(null)
+                        + ");";
+    }
+
+    @Override
+    public Document run(final MongoConnection connection) {
+        return connection.getDatabase().runCommand(command);
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractCollectionStatement.java
@@ -30,12 +30,11 @@ public abstract class AbstractCollectionStatement extends AbstractNoSqlStatement
     @Getter
     protected final String collectionName;
 
+    /**
+     * Provides a javascript representation of the command
+     *   (for example that can be ran in the mongo shell).
+     * @return javascript version of the full command
+     */
     @Override
-    public String toJs() {
-        return "db." +
-                getCommandName() +
-                "(" +
-                getCollectionName() +
-                ");";
-    }
+    public abstract String toJs();
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractCollectionStatement.java
@@ -31,10 +31,17 @@ public abstract class AbstractCollectionStatement extends AbstractNoSqlStatement
     protected final String collectionName;
 
     /**
-     * Provides a javascript representation of the command
-     *   (for example that can be ran in the mongo shell).
+     * Provides a pseudo javascript representation of the collection related statement
+     *   (for example that can be ran in the mongo shell.
+     *   Exceptions examples are count which uses db.getCollectionNames however filters programmatically by name).
      * @return javascript version of the full command
      */
     @Override
-    public abstract String toJs();
+    public String toJs() {
+        return "db." +
+                getCommandName() +
+                "(" +
+                getCollectionName() +
+                ");";
+    }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -23,16 +23,44 @@ package liquibase.ext.mongodb.statement;
 import liquibase.ext.mongodb.database.MongoConnection;
 import liquibase.nosql.statement.AbstractNoSqlStatement;
 import liquibase.nosql.statement.NoSqlExecuteStatement;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.bson.Document;
 
-public abstract class AbstractMongoDocumentStatement<T extends Document> extends AbstractNoSqlStatement
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public abstract class AbstractRunCommandStatement extends AbstractNoSqlStatement
         implements NoSqlExecuteStatement<MongoConnection> {
 
-    public abstract T run(MongoConnection connection);
+    public static final String COMMAND_NAME = "runCommand";
+    public static final String SHELL_DB_PREFIX = "db.";
+
+    @Getter
+    protected final Document command;
 
     @Override
     public void execute(final MongoConnection connection) {
         run(connection);
     }
+
+    public Document run(final MongoConnection connection) {
+        return connection.getDatabase().runCommand(command);
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public String toJs() {
+        return SHELL_DB_PREFIX
+                + getCommandName()
+                + "("
+                + BsonUtils.toJson(command)
+                + ");";
+    }
+
 
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/AdminCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AdminCommandStatement.java
@@ -25,6 +25,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.bson.Document;
 
+import static java.util.Optional.ofNullable;
+
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class AdminCommandStatement extends RunCommandStatement {

--- a/src/main/java/liquibase/ext/mongodb/statement/BsonUtils.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/BsonUtils.java
@@ -22,20 +22,11 @@ package liquibase.ext.mongodb.statement;
 
 import com.mongodb.DBRefCodecProvider;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.IndexOptions;
-import com.mongodb.client.model.ValidationAction;
-import com.mongodb.client.model.ValidationLevel;
-import com.mongodb.client.model.ValidationOptions;
 import lombok.NoArgsConstructor;
 import org.bson.Document;
 import org.bson.UuidRepresentation;
-import org.bson.codecs.BsonValueCodecProvider;
-import org.bson.codecs.DocumentCodec;
-import org.bson.codecs.DocumentCodecProvider;
-import org.bson.codecs.UuidCodec;
-import org.bson.codecs.UuidCodecProvider;
-import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.*;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -43,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static liquibase.util.StringUtil.trimToNull;
 import static lombok.AccessLevel.PRIVATE;
@@ -83,32 +73,6 @@ public final class BsonUtils {
                         .map(d -> d.getList("items", Document.class, new ArrayList<>()))
                         .orElseGet(ArrayList::new)
         );
-    }
-
-    public static CreateCollectionOptions orEmptyCreateCollectionOptions(final Document options) {
-        final CreateCollectionOptions createCollectionOptions =
-                new CreateCollectionOptions();
-
-        if (nonNull(options)) {
-            final ValidationAction
-                    validationAction =
-                    ofNullable(options.getString("validationAction"))
-                            .map(ValidationAction::fromString)
-                            .orElse(null);
-
-            final ValidationLevel
-                    validationLevel =
-                    ofNullable(options.getString("validationLevel"))
-                            .map(ValidationLevel::fromString)
-                            .orElse(null);
-
-            createCollectionOptions.validationOptions(
-                    new ValidationOptions()
-                            .validationAction(validationAction)
-                            .validationLevel(validationLevel)
-                            .validator(options.get("validator", Document.class)));
-        }
-        return createCollectionOptions;
     }
 
     public static IndexOptions orEmptyIndexOptions(final Document options) {

--- a/src/main/java/liquibase/ext/mongodb/statement/BsonUtils.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/BsonUtils.java
@@ -26,7 +26,12 @@ import com.mongodb.client.model.IndexOptions;
 import lombok.NoArgsConstructor;
 import org.bson.Document;
 import org.bson.UuidRepresentation;
-import org.bson.codecs.*;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.UuidCodec;
+import org.bson.codecs.UuidCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -34,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static liquibase.util.StringUtil.trimToNull;
 import static lombok.AccessLevel.PRIVATE;
@@ -90,4 +96,15 @@ public final class BsonUtils {
         return indexOptions;
     }
 
+    public static String toJson(final Document document) {
+        return ofNullable(document).map(Document::toJson).orElse(null);
+    }
+
+    public static Document toCommand(final String commandName, final Object commandValue, final Document options) {
+        final Document command = new Document(commandName, commandValue);
+        if (nonNull(options)) {
+            command.putAll(options);
+        }
+        return command;
+    }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
@@ -33,7 +33,7 @@ import java.util.stream.StreamSupport;
 public class CountCollectionByNameStatement extends AbstractCollectionStatement
         implements NoSqlQueryForLongStatement<MongoConnection> {
 
-    public static final String COMMAND_NAME = "countCollectionByNames";
+    public static final String COMMAND_NAME = "count";
 
     public CountCollectionByNameStatement(final String collectionName) {
         super(collectionName);
@@ -49,5 +49,10 @@ public class CountCollectionByNameStatement extends AbstractCollectionStatement
         return StreamSupport.stream(connection.getDatabase().listCollectionNames().spliterator(), false)
                 .filter(s -> s.equals(getCollectionName()))
                 .count();
+    }
+
+    @Override
+    public String toJs() {
+        return String.format("db.%s.count()", getCollectionName());
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
@@ -22,7 +22,6 @@ package liquibase.ext.mongodb.statement;
 
 import liquibase.ext.mongodb.database.MongoConnection;
 import liquibase.nosql.statement.NoSqlQueryForLongStatement;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -33,7 +32,7 @@ import java.util.stream.StreamSupport;
 public class CountCollectionByNameStatement extends AbstractCollectionStatement
         implements NoSqlQueryForLongStatement<MongoConnection> {
 
-    public static final String COMMAND_NAME = "count";
+    public static final String COMMAND_NAME = "getCollectionNames";
 
     public CountCollectionByNameStatement(final String collectionName) {
         super(collectionName);
@@ -49,10 +48,5 @@ public class CountCollectionByNameStatement extends AbstractCollectionStatement
         return StreamSupport.stream(connection.getDatabase().listCollectionNames().spliterator(), false)
                 .filter(s -> s.equals(getCollectionName()))
                 .count();
-    }
-
-    @Override
-    public String toJs() {
-        return String.format("db.%s.count()", getCollectionName());
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
@@ -20,36 +20,27 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
-import liquibase.ext.mongodb.database.MongoConnection;
-import liquibase.nosql.statement.NoSqlExecuteStatement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.bson.Document;
-import org.bson.conversions.Bson;
-
-import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
 
 /**
  * Creates a collection via the database runCommand method
  * For a list of supported options see the reference page:
- *   https://docs.mongodb.com/manual/reference/command/create/index.html
+ * https://docs.mongodb.com/manual/reference/command/create/#create
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class CreateCollectionStatement extends AbstractCollectionStatement
-        implements NoSqlExecuteStatement<MongoConnection> {
+public class CreateCollectionStatement extends AbstractRunCommandStatement {
 
-    private static final String COMMAND_NAME = "create";
-
-    private final Document options;
+    public static final String RUN_COMMAND_NAME = "create";
 
     public CreateCollectionStatement(final String collectionName, final String options) {
         this(collectionName, BsonUtils.orEmptyDocument(options));
     }
 
     public CreateCollectionStatement(final String collectionName, final Document options) {
-        super(collectionName);
-        this.options = options;
+        super(BsonUtils.toCommand(RUN_COMMAND_NAME, collectionName, options));
     }
 
     @Override
@@ -57,22 +48,4 @@ public class CreateCollectionStatement extends AbstractCollectionStatement
         return COMMAND_NAME;
     }
 
-    @Override
-    public String toJs() {
-        return String.format("db.runCommand(%s)", createCommand().toString());
-    }
-
-    @Override
-    public void execute(final MongoConnection connection) {
-        Bson bson = createCommand();
-        connection.getDatabase().runCommand(bson);
-    }
-
-    private Bson createCommand() {
-        Document commandOptions = new Document(COMMAND_NAME, getCollectionName());
-        if(options!=null) {
-            commandOptions.putAll(options);
-        }
-        return commandOptions.toBsonDocument(Document.class, getDefaultCodecRegistry());
-    }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/RunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/RunCommandStatement.java
@@ -20,47 +20,18 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
-import liquibase.ext.mongodb.database.MongoConnection;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import org.bson.Document;
 
-import static java.util.Optional.ofNullable;
-
-@Getter
 @EqualsAndHashCode(callSuper = true)
-public class RunCommandStatement extends AbstractMongoDocumentStatement<Document> {
-
-    public static final String COMMAND_NAME = "runCommand";
-
-    protected Document command;
+public class RunCommandStatement extends AbstractRunCommandStatement {
 
     public RunCommandStatement(final String command) {
         this(BsonUtils.orEmptyDocument(command));
     }
 
     public RunCommandStatement(final Document command) {
-        this.command = command;
-    }
-
-    @Override
-    public String getCommandName() {
-        return COMMAND_NAME;
-    }
-
-    @Override
-    public String toJs() {
-        return
-                "db."
-                        + getCommandName()
-                        + "("
-                        + ofNullable(command).map(Document::toJson).orElse(null)
-                        + ");";
-    }
-
-    @Override
-    public Document run(final MongoConnection connection) {
-        return connection.getDatabase().runCommand(command);
+        super(command);
     }
 
 }

--- a/src/test/java/liquibase/ext/mongodb/TestUtils.java
+++ b/src/test/java/liquibase/ext/mongodb/TestUtils.java
@@ -101,4 +101,16 @@ public final class TestUtils {
             parser.parse(changeSetPath, new ChangeLogParameters(database), resourceAccessor);
         return changeLog.getChangeSets();
     }
+
+    /**
+     * Helper to format and convert a string containing single quotes to one with double quotes.
+     * Use this to declare readable strings in tests
+     * @param singleQuoted a string containing single quotes
+     * @param args format args
+     * @return original string formatted with double quotes
+     */
+    public static final String formatDoubleQuoted(final String singleQuoted, final String... args) {
+        String formatted = String.format(singleQuoted, args);
+        return formatted.replaceAll("'","\"");
+    }
 }

--- a/src/test/java/liquibase/ext/mongodb/change/CreateCollectionChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateCollectionChangeTest.java
@@ -48,7 +48,7 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
                 .hasSize(1)
                 .first()
                 .isInstanceOf(DropCollectionStatement.class)
-                .returns("collection1", s -> ((DropCollectionStatement)s).getCollectionName());
+                .returns("collection1", s -> ((DropCollectionStatement) s).getCollectionName());
     }
 
     @Test
@@ -60,7 +60,7 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
                 .isNotNull()
                 .hasSize(1)
                 .first()
-                .returns("8:9613cffe7f07a1310ed2b6a47efb92c8",  s -> s.generateCheckSum().toString());
+                .returns("8:9613cffe7f07a1310ed2b6a47efb92c8", s -> s.generateCheckSum().toString());
 
         assertThat(changeSets.get(0).getChanges())
                 .hasSize(3)
@@ -72,9 +72,13 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
         final SqlStatement[] sqlStatement1 = ch1.generateStatements(database);
         assertThat(sqlStatement1)
                 .hasSize(1);
-        assertThat(((CreateCollectionStatement) sqlStatement1[0]))
+        assertThat(((CreateCollectionStatement) sqlStatement1[0]).getCommand())
+                .hasSize(4)
                 .hasNoNullFieldsOrProperties()
-                .hasFieldOrPropertyWithValue("collectionName", "createCollectionWithValidatorAndOptionsTest");
+                .hasFieldOrPropertyWithValue("create", "createCollectionWithValidatorAndOptionsTest")
+                .hasFieldOrPropertyWithValue("validationAction", "warn")
+                .hasFieldOrPropertyWithValue("validationLevel", "strict")
+                .hasFieldOrProperty("validator");
 
         final CreateCollectionChange ch2 = (CreateCollectionChange) changeSets.get(0).getChanges().get(1);
         assertThat(ch2.getCollectionName()).isEqualTo("createCollectionWithEmptyValidatorTest");
@@ -82,9 +86,10 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
         final SqlStatement[] sqlStatement2 = ch2.generateStatements(database);
         assertThat(sqlStatement2)
                 .hasSize(1);
-        assertThat(((CreateCollectionStatement) sqlStatement2[0]))
-                .hasNoNullFieldsOrPropertiesExcept("options")
-                .hasFieldOrPropertyWithValue("collectionName", "createCollectionWithEmptyValidatorTest");
+        assertThat(((CreateCollectionStatement) sqlStatement2[0]).getCommand())
+                .hasSize(1)
+                .hasNoNullFieldsOrProperties()
+                .hasFieldOrPropertyWithValue("create", "createCollectionWithEmptyValidatorTest");
 
         final CreateCollectionChange ch3 = (CreateCollectionChange) changeSets.get(0).getChanges().get(2);
         assertThat(ch3.getCollectionName()).isEqualTo("createCollectionWithNoValidator");
@@ -92,9 +97,9 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
         final SqlStatement[] sqlStatement3 = ch3.generateStatements(database);
         assertThat(sqlStatement3)
                 .hasSize(1);
-        assertThat(((CreateCollectionStatement) sqlStatement3[0]))
-                .hasNoNullFieldsOrPropertiesExcept("options")
-                .hasFieldOrPropertyWithValue("collectionName", "createCollectionWithNoValidator");
+        assertThat(((CreateCollectionStatement) sqlStatement3[0]).getCommand())
+                .hasSize(1)
+                .hasFieldOrPropertyWithValue("create", "createCollectionWithNoValidator");
     }
 
     @Test
@@ -115,9 +120,11 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
         final SqlStatement[] sqlStatement1 = ch1.generateStatements(database);
         assertThat(sqlStatement1)
                 .hasSize(1);
-        assertThat(((CreateCollectionStatement) sqlStatement1[0]))
+        assertThat(((CreateCollectionStatement) sqlStatement1[0]).getCommand())
+                .hasSize(1)
                 .hasNoNullFieldsOrProperties()
-                .hasFieldOrPropertyWithValue("collectionName", "person");
+                .hasFieldOrPropertyWithValue("create", "person")
+                .hasFieldOrPropertyWithValue(CreateCollectionStatement.RUN_COMMAND_NAME, "person");
 
         final CreateCollectionChange ch2 = (CreateCollectionChange) changeSets.get(0).getChanges().get(1);
         assertThat(ch2.getCollectionName()).isEqualTo("person1");
@@ -125,8 +132,11 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
         final SqlStatement[] sqlStatement2 = ch2.generateStatements(database);
         assertThat(sqlStatement2)
                 .hasSize(1);
-        assertThat(((CreateCollectionStatement) sqlStatement2[0]))
-                .hasFieldOrPropertyWithValue("collectionName", "person1")
-                .hasNoNullFieldsOrPropertiesExcept("options");
+        assertThat(((CreateCollectionStatement) sqlStatement2[0]).getCommand())
+                .hasSize(4)
+                .hasFieldOrPropertyWithValue("create", "person1")
+                .hasFieldOrPropertyWithValue("validationAction", "warn")
+                .hasFieldOrPropertyWithValue("validationLevel", "strict")
+                .hasFieldOrProperty("validator");
     }
 }

--- a/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CountCollectionByNameStatementIT extends AbstractMongoIntegrationTest {
     private static final String COLLECTION_NAME = TestUtils.COLLECTION_NAME_1;
-    private static final String COLLECTION_CMD = String.format("db.countCollectionByNames(%s);", COLLECTION_NAME);
+    private static final String COLLECTION_CMD = String.format("db.%s.count()", COLLECTION_NAME);
     private static final CountCollectionByNameStatement COUNT_COLLECTION = new CountCollectionByNameStatement(COLLECTION_NAME);
 
     @Test

--- a/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CountCollectionByNameStatementIT extends AbstractMongoIntegrationTest {
     private static final String COLLECTION_NAME = TestUtils.COLLECTION_NAME_1;
-    private static final String COLLECTION_CMD = String.format("db.%s.count()", COLLECTION_NAME);
+    private static final String COLLECTION_CMD = String.format("db.getCollectionNames(%s);", COLLECTION_NAME);
     private static final CountCollectionByNameStatement COUNT_COLLECTION = new CountCollectionByNameStatement(COLLECTION_NAME);
 
     @Test

--- a/src/test/java/liquibase/ext/mongodb/statement/CreateCollectionStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CreateCollectionStatementIT.java
@@ -52,7 +52,7 @@ class CreateCollectionStatementIT extends AbstractMongoIntegrationTest {
 
     @Test
     void toStringJsWithoutOptions() {
-        String expected = formatDoubleQuoted("db.runCommand({'create': '%s'})", collectionName);
+        String expected = formatDoubleQuoted("db.runCommand({'create': '%s'});", collectionName);
         final CreateCollectionStatement statement = new CreateCollectionStatement(collectionName, EMPTY_OPTION);
         assertThat(statement.toJs())
                 .isEqualTo(expected)
@@ -71,7 +71,7 @@ class CreateCollectionStatementIT extends AbstractMongoIntegrationTest {
     @Test
     void toStringJsWithOptions() {
         String options = String.format("{ %s }", CREATE_OPTIONS);
-        String expected = formatDoubleQuoted("db.runCommand({'create': '%s', %s})", collectionName, CREATE_OPTIONS);
+        String expected = formatDoubleQuoted("db.runCommand({'create': '%s', %s});", collectionName, CREATE_OPTIONS);
         final CreateCollectionStatement statement = new CreateCollectionStatement(collectionName, options);
         assertThat(statement.toJs())
                 .isEqualTo(expected)


### PR DESCRIPTION
Changed `CreateCollectionStatement` to execute as a mongoDB `runCommand` so that it supports all available server options.
Made `AbstractCollectionStatement.toJs()` method abstract and fixed the `CountCollectionByNameStatement` implementation of it.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1117) by [Unito](https://www.unito.io/learn-more)
