### PR TITLE
Tag the current database state

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Liquibase turned to be the most feasible tool to extend as it allows to define c
 #### 4.2.2.1
 * Fixed [Issue-64:Support for DNS Seed List Connection Format or Atlas Cluster](https://github.com/liquibase/liquibase-mongodb/issues/66)
 * Fixed [Issue-69: Does it support preconditions](https://github.com/liquibase/liquibase-mongodb/issues/69)
+* Fixed [Issue-70: Is there a way to tag the current database state?](https://github.com/liquibase/liquibase-mongodb/issues/70)  
 * Added DocumentExistsPrecondition, ExpectedDocumentCountPrecondition
 * Fixed [Issue-74: createIndex with TTL (expireAfterSeconds) is ignored and normal index created](https://github.com/liquibase/liquibase-mongodb/issues/74)
 * Fixed [Issue-79: CreateCollection silently drops supported options](https://github.com/liquibase/liquibase-mongodb/issues/79)

--- a/src/main/java/liquibase/ext/mongodb/changelog/MongoHistoryService.java
+++ b/src/main/java/liquibase/ext/mongodb/changelog/MongoHistoryService.java
@@ -36,6 +36,7 @@ import liquibase.ext.mongodb.statement.CountDocumentsInCollectionStatement;
 import liquibase.ext.mongodb.statement.DeleteManyStatement;
 import liquibase.ext.mongodb.statement.DropCollectionStatement;
 import liquibase.ext.mongodb.statement.FindAllStatement;
+import liquibase.ext.mongodb.statement.FindOneAndUpdateStatement;
 import liquibase.ext.mongodb.statement.InsertOneStatement;
 import liquibase.ext.mongodb.statement.UpdateManyStatement;
 import liquibase.logging.Logger;
@@ -222,6 +223,15 @@ public class MongoHistoryService extends AbstractNoSqlHistoryService {
         final Bson filter = Filters.eq(MongoRanChangeSet.Fields.tag, tag);
         return getExecutor().queryForLong(
                 new CountDocumentsInCollectionStatement(getDatabaseChangeLogTableName(), filter));
+    }
+
+    @Override
+    protected void tagLast(final String tagString) throws DatabaseException {
+        final Document filter = new Document();
+        final Bson update = Updates.set(MongoRanChangeSet.Fields.tag, tagString);
+        final Bson sort = Sorts.descending(MongoRanChangeSet.Fields.dateExecuted, MongoRanChangeSet.Fields.orderExecuted);
+
+        getExecutor().update(new FindOneAndUpdateStatement(getDatabaseChangeLogTableName(), filter, update, sort));
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
@@ -43,9 +43,4 @@ public class CreateCollectionStatement extends AbstractRunCommandStatement {
         super(BsonUtils.toCommand(RUN_COMMAND_NAME, collectionName, options));
     }
 
-    @Override
-    public String getCommandName() {
-        return COMMAND_NAME;
-    }
-
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/FindOneAndUpdateStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/FindOneAndUpdateStatement.java
@@ -1,0 +1,86 @@
+package liquibase.ext.mongodb.statement;
+
+/*-
+ * #%L
+ * Liquibase MongoDB Extension
+ * %%
+ * Copyright (C) 2021 Mastercard
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import liquibase.ext.mongodb.database.MongoConnection;
+import liquibase.nosql.statement.NoSqlExecuteStatement;
+import liquibase.nosql.statement.NoSqlUpdateStatement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
+import static liquibase.ext.mongodb.statement.AbstractRunCommandStatement.SHELL_DB_PREFIX;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class FindOneAndUpdateStatement extends AbstractCollectionStatement
+        implements NoSqlExecuteStatement<MongoConnection>, NoSqlUpdateStatement<MongoConnection> {
+
+    public static final String COMMAND_NAME = "updateLastTag";
+
+    private final Bson filter;
+    private final Bson document;
+    private final Bson sort;
+
+    public FindOneAndUpdateStatement(final String collectionName, final Bson filter, final Bson document, final Bson sort) {
+        super(collectionName);
+        this.filter = filter;
+        this.document = document;
+        this.sort = sort;
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public String toJs() {
+        return
+                SHELL_DB_PREFIX +
+                        getCollectionName() +
+                        "." +
+                        getCommandName() +
+                        "(" +
+                        ofNullable(filter).map(Bson::toString).orElse(null) +
+                        ", " +
+                        ofNullable(document).map(Bson::toString).orElse(null) +
+                        ", " +
+                        ofNullable(sort).map(Bson::toString).orElse(null) +
+                        ");";
+    }
+
+    @Override
+    public void execute(final MongoConnection connection) {
+        update(connection);
+    }
+
+    @Override
+    public int update(final MongoConnection connection) {
+        final MongoCollection<Document> collection = connection.getDatabase().getCollection(getCollectionName());
+        return isNull(collection.findOneAndUpdate(filter, document, new FindOneAndUpdateOptions().sort(sort))) ? 0 : 1;
+    }
+}

--- a/src/main/java/liquibase/nosql/changelog/AbstractNoSqlHistoryService.java
+++ b/src/main/java/liquibase/nosql/changelog/AbstractNoSqlHistoryService.java
@@ -216,6 +216,8 @@ public abstract class AbstractNoSqlHistoryService extends AbstractChangeLogHisto
             this.setExecType(emptyChangeSet, ChangeSet.ExecType.EXECUTED);
         }
 
+        tagLast(tagString);
+
         if (this.ranChangeSetList != null) {
             ranChangeSetList.get(ranChangeSetList.size() - 1).setTag(tagString);
         }
@@ -280,6 +282,8 @@ public abstract class AbstractNoSqlHistoryService extends AbstractChangeLogHisto
     protected abstract void clearChekSums() throws DatabaseException;
 
     protected abstract long countTags(String tag) throws DatabaseException;
+
+    protected abstract void tagLast(String tagString) throws DatabaseException;
 
     protected abstract long countRanChangeSets() throws DatabaseException;
 

--- a/src/test/java/liquibase/ext/MongoLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/MongoLiquibaseIT.java
@@ -23,6 +23,7 @@ package liquibase.ext;
 import liquibase.Liquibase;
 import liquibase.change.CheckSum;
 import liquibase.exception.LiquibaseException;
+import liquibase.exception.RollbackFailedException;
 import liquibase.ext.mongodb.changelog.MongoRanChangeSet;
 import liquibase.ext.mongodb.changelog.MongoRanChangeSetToDocumentConverter;
 import liquibase.ext.mongodb.statement.FindAllStatement;
@@ -40,6 +41,7 @@ import static liquibase.changelog.ChangeSet.ExecType.EXECUTED;
 import static liquibase.changelog.ChangeSet.ExecType.SKIPPED;
 import static liquibase.ext.mongodb.TestUtils.getCollections;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
 
 class MongoLiquibaseIT extends AbstractMongoIntegrationTest {
@@ -270,6 +272,135 @@ class MongoLiquibaseIT extends AbstractMongoIntegrationTest {
                 .hasSize(4).extracting(d -> d.get("info"))
                 .containsExactlyInAnyOrder("existsAnyDocumentInCollection1", "filterMatchedInCollection1", "changeSetExecutedMatch", "expectedDocumentCountfilterMatchedInCollection1");
 
+    }
+
+    @SneakyThrows
+    @Test
+    void testTags() {
+        final Liquibase liquibase = new Liquibase("liquibase/ext/changelog.insert-tags.test.xml", new ClassLoaderResourceAccessor(), database);
+
+        // tag on an empty DB
+        liquibase.tag("tag0");
+
+        List<MongoRanChangeSet> changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(1)
+                .extracting(MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple( 1, EXECUTED, "tag0")
+                );
+
+        final FindAllStatement findAllResults = new FindAllStatement("results");
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(0);
+
+        // update to tag
+        liquibase.dropAll();
+        liquibase.update("tag5", "");
+        changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(5)
+                .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple("1", 1, EXECUTED, null),
+                        tuple("2", 2, EXECUTED, "tag2"),
+                        tuple("3", 3, EXECUTED, null),
+                        tuple("4", 4, EXECUTED, null),
+                        tuple("5", 5, EXECUTED, "tag5")
+                );
+
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(3).extracting(d -> d.get("info"))
+                .containsExactlyInAnyOrder("row1", "row3", "row4");
+
+        liquibase.update("");
+        changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(6)
+                .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple("1", 1, EXECUTED, null),
+                        tuple("2", 2, EXECUTED, "tag2"),
+                        tuple("3", 3, EXECUTED, null),
+                        tuple("4", 4, EXECUTED, null),
+                        tuple("5", 5, EXECUTED, "tag5"),
+                        tuple("6", 6, EXECUTED, null)
+                );
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(4).extracting(d -> d.get("info"))
+                .containsExactlyInAnyOrder("row1", "row3", "row4", "row6");
+
+        // tag current state
+        liquibase.tag("tag6");
+        changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(6)
+                .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple("1", 1, EXECUTED, null),
+                        tuple("2", 2, EXECUTED, "tag2"),
+                        tuple("3", 3, EXECUTED, null),
+                        tuple("4", 4, EXECUTED, null),
+                        tuple("5", 5, EXECUTED, "tag5"),
+                        tuple("6", 6, EXECUTED, "tag6")
+                );
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(4).extracting(d -> d.get("info"))
+                .containsExactlyInAnyOrder("row1", "row3", "row4", "row6");
+
+        // re tag current state
+        liquibase.tag("retag6");
+        changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(6)
+                .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple("1", 1, EXECUTED, null),
+                        tuple("2", 2, EXECUTED, "tag2"),
+                        tuple("3", 3, EXECUTED, null),
+                        tuple("4", 4, EXECUTED, null),
+                        tuple("5", 5, EXECUTED, "tag5"),
+                        tuple("6", 6, EXECUTED, "retag6")
+                );
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(4).extracting(d -> d.get("info"))
+                .containsExactlyInAnyOrder("row1", "row3", "row4", "row6");
+
+        assertThat(getCollections(connection))
+                .hasSize(3)
+                .containsExactlyInAnyOrder("DATABASECHANGELOG", "DATABASECHANGELOGLOCK", "results");
+
+        // rollback to not existing
+        assertThatExceptionOfType(RollbackFailedException.class).isThrownBy(()-> liquibase.rollback("notExisting", ""))
+                .withMessageContaining("Could not find tag 'notExisting' in the database");
+
+        // rollback to tagged state. Tagged ChangeSet remains
+        liquibase.rollback("retag6", "");
+        changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(6)
+                .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple("1", 1, EXECUTED, null),
+                        tuple("2", 2, EXECUTED, "tag2"),
+                        tuple("3", 3, EXECUTED, null),
+                        tuple("4", 4, EXECUTED, null),
+                        tuple("5", 5, EXECUTED, "tag5"),
+                        tuple("6", 6, EXECUTED, "retag6")
+                );
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(4).extracting(d -> d.get("info"))
+                .containsExactlyInAnyOrder("row1", "row3", "row4", "row6");
+        assertThat(liquibase.tagExists("retag6")).isTrue();
+
+        // rollback to tag2 tag ChangeSet is removed
+        assertThat(liquibase.tagExists("tag2")).isTrue();
+        liquibase.rollback("tag2", "");
+        changeSets = findAllRanChangeSets.queryForList(connection).stream().map(converter::fromDocument).collect(Collectors.toList());
+        assertThat(changeSets).hasSize(1)
+                .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getTag)
+                .containsExactly(
+                        tuple("1", 1, EXECUTED, null)
+                );
+        assertThat(findAllResults.queryForList(connection))
+                .hasSize(1).extracting(d -> d.get("info"))
+                .containsExactlyInAnyOrder("row1");
+
+        assertThat(liquibase.tagExists("tag2")).isFalse();
     }
 
 }

--- a/src/test/resources/liquibase/ext/changelog.insert-tags.test.xml
+++ b/src/test/resources/liquibase/ext/changelog.insert-tags.test.xml
@@ -1,0 +1,143 @@
+<!--
+  #%L
+  Liquibase MongoDB Extension
+  %%
+  Copyright (C) 2021 Mastercard
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="1" author="alex">
+
+        <ext:insertOne collectionName="results">
+            <ext:document>
+                <!--@formatter:off-->
+                {
+                    info: "row1"
+                }
+                <!--@formatter:on-->
+            </ext:document>
+        </ext:insertOne>
+
+        <rollback>
+            <ext:runCommand>
+                <ext:command>
+                    <!--@formatter:off-->
+                    {
+                        delete: "results",
+                        deletes: [{q: {info: "row1"}, limit: 0}]
+                    }
+                    <!--@formatter:on-->
+                </ext:command>
+            </ext:runCommand>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="2" author="alex">
+        <tagDatabase tag="tag2"/>
+    </changeSet>
+
+    <changeSet id="3" author="alex">
+
+        <ext:insertOne collectionName="results">
+            <ext:document>
+                <!--@formatter:off-->
+                {
+                    info: "row3"
+                }
+                <!--@formatter:on-->
+            </ext:document>
+        </ext:insertOne>
+
+        <rollback>
+            <ext:runCommand>
+                <ext:command>
+                    <!--@formatter:off-->
+                    {
+                        delete: "results",
+                        deletes: [{q: {info: "row3"}, limit: 0}]
+                    }
+                    <!--@formatter:on-->
+                </ext:command>
+            </ext:runCommand>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="4" author="alex">
+
+        <ext:insertOne collectionName="results">
+            <ext:document>
+                <!--@formatter:off-->
+                {
+                    info: "row4"
+                }
+                <!--@formatter:on-->
+            </ext:document>
+        </ext:insertOne>
+
+        <rollback>
+            <ext:runCommand>
+                <ext:command>
+                    <!--@formatter:off-->
+                    {
+                        delete: "results",
+                        deletes: [{q: {info: "row4"}, limit: 0}]
+                    }
+                    <!--@formatter:on-->
+                </ext:command>
+            </ext:runCommand>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="5" author="alex">
+        <tagDatabase tag="tag5"/>
+    </changeSet>
+
+    <changeSet id="6" author="alex">
+
+        <ext:insertOne collectionName="results">
+            <ext:document>
+                <!--@formatter:off-->
+                {
+                    info: "row6"
+                }
+                <!--@formatter:on-->
+            </ext:document>
+        </ext:insertOne>
+
+        <rollback>
+            <ext:runCommand>
+                <ext:command>
+                    <!--@formatter:off-->
+                    {
+                        delete: "results",
+                        deletes: [{q: {info: "row6"}, limit: 0}]
+                    }
+                    <!--@formatter:on-->
+                </ext:command>
+            </ext:runCommand>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/liquibase/ext/json/changelog.insert-tags.json
+++ b/src/test/resources/liquibase/ext/json/changelog.insert-tags.json
@@ -1,0 +1,178 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "1",
+        "author": "Nick",
+        "changes": [
+          {
+            "insertOne": {
+              "collectionName": "results",
+              "document": {
+                "$rawJson": {
+                  "info": "row1"
+                }
+              }
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "runCommand": {
+              "command": {
+                "$rawJson": {
+                  "delete": "results",
+                  "deletes": [
+                    {
+                      "q": {
+                        "info": "row1"
+                      },
+                      "limit": 0
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "2",
+        "author": "Nick",
+        "changes": [
+          {
+            "tagDatabase": {
+              "tag": "tag2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "3",
+        "author": "Nick",
+        "changes": [
+          {
+            "insertOne": {
+              "collectionName": "results",
+              "document": {
+                "$rawJson": {
+                  "info": "row3"
+                }
+              }
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "runCommand": {
+              "command": {
+                "$rawJson": {
+                  "delete": "results",
+                  "deletes": [
+                    {
+                      "q": {
+                        "info": "row3"
+                      },
+                      "limit": 0
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "4",
+        "author": "Nick",
+        "changes": [
+          {
+            "insertOne": {
+              "collectionName": "results",
+              "document": {
+                "$rawJson": {
+                  "info": "row4"
+                }
+              }
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "runCommand": {
+              "command": {
+                "$rawJson": {
+                  "delete": "results",
+                  "deletes": [
+                    {
+                      "q": {
+                        "info": "row4"
+                      },
+                      "limit": 0
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "5",
+        "author": "Nick",
+        "changes": [
+          {
+            "tagDatabase": {
+              "tag": "tag5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "6",
+        "author": "Nick",
+        "changes": [
+          {
+            "insertOne": {
+              "collectionName": "results",
+              "document": {
+                "$rawJson": {
+                  "info": "row6"
+                }
+              }
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "runCommand": {
+              "command": {
+                "$rawJson": {
+                  "delete": "results",
+                  "deletes": [
+                    {
+                      "q": {
+                        "info": "row6"
+                      },
+                      "limit": 0
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #70 
Fixed last state tag. tagDatabase works out of the box. Added integration tests for xml and json/
`
MongoLiquibaseIT#testTags->changelog.insert-tags.test.xml
MongoLiquibaseJsonIT#testTags->changelog.insert-tags.json
`



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1150) by [Unito](https://www.unito.io/learn-more)
