### PR TITLE
Convert insertOne statement to execute as a runCommand operation

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -20,6 +20,7 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
+import com.mongodb.MongoException;
 import liquibase.ext.mongodb.database.MongoConnection;
 import liquibase.nosql.statement.AbstractNoSqlStatement;
 import liquibase.nosql.statement.NoSqlExecuteStatement;
@@ -41,12 +42,20 @@ public abstract class AbstractRunCommandStatement extends AbstractNoSqlStatement
 
     @Override
     public void execute(final MongoConnection connection) {
-        run(connection);
+        Document response = run(connection);
+        checkResponse(response);
     }
 
     public Document run(final MongoConnection connection) {
         return connection.getDatabase().runCommand(command);
     }
+
+    /**
+     * Check the response and throw an appropriate exception if the command was not successful
+     * @param responseDocument the response document
+     * @throws MongoException a MongoException to be thrown
+     */
+    abstract void checkResponse(Document responseDocument) throws MongoException;
 
     @Override
     public String getCommandName() {

--- a/src/main/java/liquibase/ext/mongodb/statement/BsonUtils.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/BsonUtils.java
@@ -48,6 +48,9 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 @NoArgsConstructor(access = PRIVATE)
 public final class BsonUtils {
 
+    public static final String WRITE_ERRORS = "writeErrors";
+    public static final String DOCUMENTS = "documents";
+
     public static final DocumentCodec DOCUMENT_CODEC =
             new DocumentCodec(fromProviders(
                     new UuidCodecProvider(UuidRepresentation.STANDARD),

--- a/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
@@ -20,7 +20,6 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
-import com.mongodb.MongoException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.bson.Document;
@@ -44,14 +43,8 @@ public class CreateCollectionStatement extends AbstractRunCommandStatement {
         super(BsonUtils.toCommand(RUN_COMMAND_NAME, collectionName, options));
     }
 
-    /**
-     * The server responds with { "ok": 0 } (failure) if this command fails
-     * Therefore the response document does not need to be explicitly checked.
-     * @param responseDocument the response document
-     * @throws MongoException - does not throw in this case
-     */
     @Override
-    void checkResponse(Document responseDocument) throws MongoException {
-        // NoOp
+    public String getRunCommandName() {
+        return RUN_COMMAND_NAME;
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CreateCollectionStatement.java
@@ -20,6 +20,7 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
+import com.mongodb.MongoException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.bson.Document;
@@ -43,4 +44,14 @@ public class CreateCollectionStatement extends AbstractRunCommandStatement {
         super(BsonUtils.toCommand(RUN_COMMAND_NAME, collectionName, options));
     }
 
+    /**
+     * The server responds with { "ok": 0 } (failure) if this command fails
+     * Therefore the response document does not need to be explicitly checked.
+     * @param responseDocument the response document
+     * @throws MongoException - does not throw in this case
+     */
+    @Override
+    void checkResponse(Document responseDocument) throws MongoException {
+        // NoOp
+    }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/RunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/RunCommandStatement.java
@@ -20,7 +20,6 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
-import com.mongodb.MongoException;
 import lombok.EqualsAndHashCode;
 import org.bson.Document;
 
@@ -36,15 +35,11 @@ public class RunCommandStatement extends AbstractRunCommandStatement {
     }
 
     /**
-     * Responses are not checked for adhoc commands.
-     * This could result in unexpected behaviour
-     * TODO: Minimally check if { "ok": 0 } and throw an exception containing the responseDocument
-     *
-     * @param responseDocument the response document
-     * @throws MongoException does not throw in this case
+     * Returns the RunCommand command name
+     * @return null as this is not used and not required for a generic RunCommandStatement
      */
     @Override
-    void checkResponse(Document responseDocument) throws MongoException {
-        // NoOp
+    public String getRunCommandName() {
+        return null;
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/RunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/RunCommandStatement.java
@@ -20,6 +20,7 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
+import com.mongodb.MongoException;
 import lombok.EqualsAndHashCode;
 import org.bson.Document;
 
@@ -34,4 +35,16 @@ public class RunCommandStatement extends AbstractRunCommandStatement {
         super(command);
     }
 
+    /**
+     * Responses are not checked for adhoc commands.
+     * This could result in unexpected behaviour
+     * TODO: Minimally check if { "ok": 0 } and throw an exception containing the responseDocument
+     *
+     * @param responseDocument the response document
+     * @throws MongoException does not throw in this case
+     */
+    @Override
+    void checkResponse(Document responseDocument) throws MongoException {
+        // NoOp
+    }
 }

--- a/src/test/java/liquibase/ext/mongodb/statement/CreateCollectionStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CreateCollectionStatementIT.java
@@ -20,6 +20,7 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
+import com.mongodb.MongoCommandException;
 import liquibase.ext.AbstractMongoIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,8 @@ import static liquibase.ext.mongodb.TestUtils.EMPTY_OPTION;
 import static liquibase.ext.mongodb.TestUtils.getCollections;
 import static liquibase.ext.mongodb.TestUtils.formatDoubleQuoted;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 class CreateCollectionStatementIT extends AbstractMongoIntegrationTest {
 
@@ -76,5 +79,15 @@ class CreateCollectionStatementIT extends AbstractMongoIntegrationTest {
         assertThat(statement.toJs())
                 .isEqualTo(expected)
                 .isEqualTo(statement.toString());
+    }
+
+    @Test
+    void cannotCreateExistingCollection() {
+        final CreateCollectionStatement statement = new CreateCollectionStatement(collectionName, "{}");
+        statement.execute(connection);
+
+        assertThatExceptionOfType(MongoCommandException.class)
+                .isThrownBy(() -> statement.execute(connection))
+                .withMessageContaining("Collection already exists");
     }
 }

--- a/src/test/java/liquibase/ext/mongodb/statement/CreateCollectionStatementTest.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CreateCollectionStatementTest.java
@@ -4,7 +4,7 @@ package liquibase.ext.mongodb.statement;
  * #%L
  * Liquibase MongoDB Extension
  * %%
- * Copyright (C) 2019 Mastercard
+ * Copyright (C) 2021 Mastercard
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -20,20 +20,16 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
-import com.mongodb.MongoCommandException;
-import liquibase.ext.AbstractMongoIntegrationTest;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static liquibase.ext.mongodb.TestUtils.COLLECTION_NAME_1;
 import static liquibase.ext.mongodb.TestUtils.EMPTY_OPTION;
-import static liquibase.ext.mongodb.TestUtils.getCollections;
+import static liquibase.ext.mongodb.TestUtils.formatDoubleQuoted;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
-class CreateCollectionStatementIT extends AbstractMongoIntegrationTest {
+class CreateCollectionStatementTest {
 
     // Some of the extra options that create collection supports
     private static final String CREATE_OPTIONS = "'capped': true, 'size': 100, 'max': 200";
@@ -46,32 +42,27 @@ class CreateCollectionStatementIT extends AbstractMongoIntegrationTest {
     }
 
     @Test
-    @SneakyThrows
-    void executeStatementWithoutOptions() {
+    void toStringJsWithoutOptions() {
+        String expected = formatDoubleQuoted("db.runCommand({'create': '%s'});", collectionName);
         final CreateCollectionStatement statement = new CreateCollectionStatement(collectionName, EMPTY_OPTION);
-        statement.execute(connection);
-        assertThat(getCollections(connection))
-            .contains(collectionName);
+        assertThat(statement.toJs())
+                .isEqualTo(expected)
+                .isEqualTo(statement.toString());
     }
 
-    @Test
-    @SneakyThrows
-    void executeStatementWithOptions() {
+     @Test
+    void toStringJsWithOptions() {
         String options = String.format("{ %s }", CREATE_OPTIONS);
+        String expected = formatDoubleQuoted("db.runCommand({'create': '%s', %s});", collectionName, CREATE_OPTIONS);
         final CreateCollectionStatement statement = new CreateCollectionStatement(collectionName, options);
-        statement.execute(connection);
-        assertThat(getCollections(connection))
-                .contains(collectionName);
+        assertThat(statement.toJs())
+                .isEqualTo(expected)
+                .isEqualTo(statement.toString());
     }
 
     @Test
-    @SneakyThrows
-    void cannotCreateExistingCollection() {
-        final CreateCollectionStatement statement = new CreateCollectionStatement(collectionName, "{}");
-        statement.execute(connection);
-
-        assertThatExceptionOfType(MongoCommandException.class)
-                .isThrownBy(() -> statement.execute(connection))
-                .withMessageContaining("already exists");
+    void getRunCommandName() {
+        assertThat(new CreateCollectionStatement(collectionName, EMPTY_OPTION).getRunCommandName()).isEqualTo("create");
+        assertThat(new CreateCollectionStatement(collectionName, EMPTY_OPTION).getCommandName()).isEqualTo("runCommand");
     }
 }

--- a/src/test/java/liquibase/ext/mongodb/statement/InsertOneStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/InsertOneStatementIT.java
@@ -20,13 +20,12 @@ package liquibase.ext.mongodb.statement;
  * #L%
  */
 
-import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
-import com.mongodb.MongoWriteException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoDatabase;
 import liquibase.ext.AbstractMongoIntegrationTest;
 import liquibase.ext.mongodb.TestUtils;
+import lombok.SneakyThrows;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +44,7 @@ class InsertOneStatementIT extends AbstractMongoIntegrationTest {
     }
 
     @Test
+    @SneakyThrows
     void executeForObject() {
         final MongoDatabase database = connection.getDatabase();
         final Document document = new Document("key1", "value1");
@@ -58,6 +58,7 @@ class InsertOneStatementIT extends AbstractMongoIntegrationTest {
     }
 
     @Test
+    @SneakyThrows
     void executeForString() {
         final MongoDatabase database = connection.getDatabase();
         final Document document = new Document("key1", "value1");
@@ -71,25 +72,28 @@ class InsertOneStatementIT extends AbstractMongoIntegrationTest {
     }
 
     @Test
+    @SneakyThrows
     void toStringJs() {
         String expected = TestUtils.formatDoubleQuoted(
-                "db.runCommand({'insert': '%s', 'documents': [{'key1': 'value1'}], 'ordered': false});",collectionName);
+                "db.runCommand({'insert': '%s', 'documents': [{'key1': 'value1'}], 'ordered': false});", collectionName);
         final InsertOneStatement statement = new InsertOneStatement(
                 collectionName,
                 new Document("key1", "value1"),
-                new Document("ordered",false));
+                new Document("ordered", false));
         assertThat(statement.toJs())
                 .isEqualTo(statement.toString())
                 .isEqualTo(expected);
     }
 
     @Test
+    @SneakyThrows
     void cannotInsertSameDocumentTwice() {
         final InsertOneStatement statement = new InsertOneStatement(collectionName, new Document("_id", "theId"), new Document());
         statement.execute(connection);
 
-        assertThatExceptionOfType(MongoWriteException.class)
+        assertThatExceptionOfType(MongoException.class)
                 .isThrownBy(() -> statement.execute(connection))
-                .withMessageContaining("E11000 duplicate key error");
+                .withMessageStartingWith("Command failed. The full response is")
+                .withMessageContaining("E11000 duplicate key error collection");
     }
 }

--- a/src/test/java/liquibase/ext/mongodb/statement/MongoStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/MongoStatementIT.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MongoStatementIT extends AbstractMongoIntegrationTest {
 
     @Test
+    @SneakyThrows
     void testInsertOneStatement() {
 
         final String collectionName = "logCollection";
@@ -128,7 +129,6 @@ class MongoStatementIT extends AbstractMongoIntegrationTest {
                     .countDocuments()).isEqualTo(2L);
 
     }
-
 
     @Test
     void testInsertManyChange() throws LiquibaseException {

--- a/src/test/java/liquibase/ext/mongodb/statement/RunCommandStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/RunCommandStatementIT.java
@@ -23,6 +23,7 @@ package liquibase.ext.mongodb.statement;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoDatabase;
 import liquibase.ext.AbstractMongoIntegrationTest;
+import lombok.SneakyThrows;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +42,7 @@ class RunCommandStatementIT extends AbstractMongoIntegrationTest {
         + "}";
 
     @Test
+    @SneakyThrows
     void runFromString() {
         final MongoDatabase database = connection.getDatabase();
         new RunCommandStatement(INSERT_CMD).execute(connection);
@@ -52,6 +54,7 @@ class RunCommandStatementIT extends AbstractMongoIntegrationTest {
     }
 
     @Test
+    @SneakyThrows
     void runFromDocument() {
         final MongoDatabase database = connection.getDatabase();
         new RunCommandStatement(Document.parse(INSERT_CMD)).execute(connection);


### PR DESCRIPTION
The error handling was more complicated than I had initially expected.
Wanted to raise this PR to give early visibility of the type of checking needed when using `runCommand` for this operation.
Noting that:


* InsertMany will be slightly more complicated than this case - due to the potential for multiple documents failing to insert.
* There is currently **NO** error checking of server responses from the existing `runCommand` and `adminCommand` operations. This could pose a risk in failing to report commands that failed. I think this could be covered in a new issue (happy to log it later).

Finally added an error check test for `CreateCollectionStatement` as I was paranoid errors are no longer checked, but this is not the case as the server reports these differently from the `insert` operation.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1159) by [Unito](https://www.unito.io/learn-more)
