### PR TITLE
Issue #90 Convert to RunCommand: CountCollectionByNameStatement + int…

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -47,12 +47,13 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
 
     @Override
     public void execute(final MongoLiquibaseDatabase database) {
-        final Document response = run(database);
-        checkResponse(response);
+        run(database);
     }
 
     public Document run(final MongoLiquibaseDatabase database) {
-        return database.getMongoDatabase().runCommand(command);
+        final Document response = database.getMongoDatabase().runCommand(command);
+        checkResponse(response);
+        return response;
     }
 
     /**

--- a/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
@@ -32,24 +32,15 @@ import org.bson.Document;
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class CountCollectionByNameStatement extends AbstractCollectionStatement
+public class CountCollectionByNameStatement extends ListCollectionNamesStatement
         implements NoSqlQueryForLongStatement<MongoLiquibaseDatabase> {
 
-    public static final String COMMAND_NAME = "getCollectionNames";
-
     public CountCollectionByNameStatement(final String collectionName) {
-        super(collectionName);
-    }
-
-    @Override
-    public String getCommandName() {
-        return COMMAND_NAME;
+        super(new Document(NAME, collectionName));
     }
 
     @Override
     public long queryForLong(final MongoLiquibaseDatabase database) {
-        Document filter = new Document("name", getCollectionName());
-        ListCollectionNamesStatement statement = new ListCollectionNamesStatement(filter);
-        return statement.queryForList(database).size();
+        return super.queryForList(database).size();
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatement.java
@@ -24,9 +24,12 @@ import liquibase.ext.mongodb.database.MongoLiquibaseDatabase;
 import liquibase.nosql.statement.NoSqlQueryForLongStatement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.bson.Document;
 
-import java.util.stream.StreamSupport;
-
+/**
+ * Queries the database for the number of collections that match the supplied collectionName
+ * i.e returns 1 if the collection is present; else 0
+ */
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class CountCollectionByNameStatement extends AbstractCollectionStatement
@@ -45,8 +48,8 @@ public class CountCollectionByNameStatement extends AbstractCollectionStatement
 
     @Override
     public long queryForLong(final MongoLiquibaseDatabase database) {
-        return StreamSupport.stream(database.getMongoDatabase().listCollectionNames().spliterator(), false)
-                .filter(s -> s.equals(getCollectionName()))
-                .count();
+        Document filter = new Document("name", getCollectionName());
+        ListCollectionNamesStatement statement = new ListCollectionNamesStatement(filter);
+        return statement.queryForList(database).size();
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/statement/DropAllCollectionsStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/DropAllCollectionsStatement.java
@@ -42,7 +42,7 @@ public class DropAllCollectionsStatement extends AbstractMongoStatement implemen
 
     @Override
     public void execute(final MongoLiquibaseDatabase database) {
-        database.getMongoDatabase().listCollectionNames()
+        new ListCollectionNamesStatement().queryForList(database).stream()
             .map(DropCollectionStatement::new)
             .forEach((Consumer<? super DropCollectionStatement>) s -> s.execute(database));
     }

--- a/src/main/java/liquibase/ext/mongodb/statement/DropCollectionStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/DropCollectionStatement.java
@@ -24,6 +24,7 @@ import liquibase.ext.mongodb.database.MongoLiquibaseDatabase;
 import liquibase.nosql.statement.NoSqlExecuteStatement;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.bson.Document;
 
 import static liquibase.ext.mongodb.statement.BsonUtils.toCommand;
 
@@ -41,7 +42,11 @@ public class DropCollectionStatement extends AbstractRunCommandStatement
     public static final String RUN_COMMAND_NAME = "drop";
 
     public DropCollectionStatement(final String collectionName) {
-        super(toCommand(RUN_COMMAND_NAME, collectionName, null));
+        this(collectionName, new Document());
+    }
+
+    public DropCollectionStatement(final String collectionName, Document options) {
+        super(toCommand(RUN_COMMAND_NAME, collectionName, options));
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/statement/InsertManyStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/InsertManyStatement.java
@@ -30,10 +30,12 @@ import java.util.List;
 import static java.util.Objects.nonNull;
 import static liquibase.ext.mongodb.statement.BsonUtils.orEmptyDocument;
 import static liquibase.ext.mongodb.statement.BsonUtils.orEmptyList;
+import static liquibase.ext.mongodb.statement.BsonUtils.toCommand;
 
 /**
  * Inserts many documents via the database runCommand method
  * For a list of supported options see the reference page:
+ *
  * @see <a href="https://docs.mongodb.com/manual/reference/command/insert/">insert</a>
  */
 @Getter
@@ -53,11 +55,11 @@ public class InsertManyStatement extends AbstractRunCommandStatement {
     }
 
     public InsertManyStatement(final String collectionName, final List<Document> documents, final Document options) {
-        super(BsonUtils.toCommand(RUN_COMMAND_NAME, collectionName, combine(documents, options)));
+        super(toCommand(RUN_COMMAND_NAME, collectionName, combine(documents, options)));
     }
 
     public InsertManyStatement(final String collectionName, final List<Document> documents) {
-        this( collectionName, documents, new Document());
+        this(collectionName, documents, new Document());
     }
 
     private static Document combine(final List<Document> documents, final Document options) {

--- a/src/main/java/liquibase/ext/mongodb/statement/InsertManyStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/InsertManyStatement.java
@@ -34,7 +34,7 @@ import static liquibase.ext.mongodb.statement.BsonUtils.orEmptyList;
 /**
  * Inserts many documents via the database runCommand method
  * For a list of supported options see the reference page:
- * https://docs.mongodb.com/manual/reference/command/insert/
+ * @see <a href="https://docs.mongodb.com/manual/reference/command/insert/">insert</a>
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/liquibase/ext/mongodb/statement/InsertOneStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/InsertOneStatement.java
@@ -30,6 +30,7 @@ import static liquibase.ext.mongodb.statement.BsonUtils.orEmptyDocument;
 /**
  * Inserts a document via the database runCommand method
  * For a list of supported options see the reference page:
+ *
  * @see <a href="https://docs.mongodb.com/manual/reference/command/insert/">insert</a>
  */
 @Getter

--- a/src/main/java/liquibase/ext/mongodb/statement/InsertOneStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/InsertOneStatement.java
@@ -30,7 +30,7 @@ import static liquibase.ext.mongodb.statement.BsonUtils.orEmptyDocument;
 /**
  * Inserts a document via the database runCommand method
  * For a list of supported options see the reference page:
- * @see <a href="https://docs.mongodb.com/manual/reference/command/insert/">Insert</a>
+ * @see <a href="https://docs.mongodb.com/manual/reference/command/insert/">insert</a>
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/liquibase/ext/mongodb/statement/ListCollectionNamesStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/ListCollectionNamesStatement.java
@@ -1,0 +1,91 @@
+package liquibase.ext.mongodb.statement;
+
+/*-
+ * #%L
+ * Liquibase MongoDB Extension
+ * %%
+ * Copyright (C) 2021 Mastercard
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import liquibase.ext.mongodb.database.MongoLiquibaseDatabase;
+import liquibase.nosql.statement.NoSqlQueryForListStatement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.bson.Document;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static liquibase.ext.mongodb.statement.AbstractRunCommandStatement.SHELL_DB_PREFIX;
+
+/**
+ * Gets a list of collection names via the database runCommand method
+ * For a list of supported options see the reference page:
+ * @see <a href="https://docs.mongodb.com/manual/reference/command/listCollections/">listCollections</a>
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class ListCollectionNamesStatement extends AbstractMongoStatement
+        implements NoSqlQueryForListStatement<MongoLiquibaseDatabase, String> {
+
+    static final String COMMAND_NAME = "listCollections";
+
+    private final Document filter;
+
+    /**
+     * Create a listCollections statement with no filter.
+     * i.e to return all collection names
+     */
+    public ListCollectionNamesStatement() {
+        this(new Document());
+    }
+
+    /**
+     * Create a listCollections statement with the supplied filter.
+     * @param filter the filter to apply
+     */
+    public ListCollectionNamesStatement(final Document filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<String> queryForList(final MongoLiquibaseDatabase database) {
+        Document command = createCommand();
+        Document response = database.getMongoDatabase().runCommand(command);
+        List<Document> firstBatch = response.get("cursor", Document.class).get("firstBatch", List.class);
+        return firstBatch.stream()
+                .map(document -> document.getString("name"))
+                .collect(Collectors.toList());
+    }
+
+    private Document createCommand() {
+        Document command = new Document(COMMAND_NAME, 1);
+        command.put("filter", filter);
+        return command;
+    }
+
+    public String toJs() {
+        return
+                SHELL_DB_PREFIX + AbstractRunCommandStatement.COMMAND_NAME +
+                        "("+createCommand().toJson()+");";
+    }
+}

--- a/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
@@ -29,14 +29,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CountCollectionByNameStatementIT extends AbstractMongoIntegrationTest {
     private static final String COLLECTION_NAME = TestUtils.COLLECTION_NAME_1;
-    private static final String COLLECTION_CMD = String.format("db.getCollectionNames(%s);", COLLECTION_NAME);
-    private static final CountCollectionByNameStatement COUNT_COLLECTION = new CountCollectionByNameStatement(COLLECTION_NAME);
+    private static final String COLLECTION_CMD = "db.runCommand({\"listCollections\": 1, \"filter\": {\"name\": \"collectionName\"}, \"authorizedCollections\": true, \"nameOnly\": true});";
 
     @Test
     void testQueryForLongIsOneWhenCollectionIsPresent() {
         connection.getMongoDatabase().createCollection(COLLECTION_NAME_1);
         assertThat(new CountCollectionByNameStatement(COLLECTION_NAME_1).queryForLong(database))
-            .isEqualTo(1);
+                .isEqualTo(1);
     }
 
     @Test
@@ -47,8 +46,9 @@ class CountCollectionByNameStatementIT extends AbstractMongoIntegrationTest {
 
     @Test
     void shouldReturnToString() {
-        assertThat(COUNT_COLLECTION.toJs())
-            .isEqualTo(COUNT_COLLECTION.toString())
-            .isEqualTo(COLLECTION_CMD, COLLECTION_NAME);
+        final CountCollectionByNameStatement countCollectionByNameStatement = new CountCollectionByNameStatement(COLLECTION_NAME);
+        assertThat(countCollectionByNameStatement.toJs())
+                .isEqualTo(countCollectionByNameStatement.toString())
+                .isEqualTo(COLLECTION_CMD);
     }
 }

--- a/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/CountCollectionByNameStatementIT.java
@@ -33,10 +33,16 @@ class CountCollectionByNameStatementIT extends AbstractMongoIntegrationTest {
     private static final CountCollectionByNameStatement COUNT_COLLECTION = new CountCollectionByNameStatement(COLLECTION_NAME);
 
     @Test
-    void queryForLong() {
+    void testQueryForLongIsOneWhenCollectionIsPresent() {
         connection.getMongoDatabase().createCollection(COLLECTION_NAME_1);
         assertThat(new CountCollectionByNameStatement(COLLECTION_NAME_1).queryForLong(database))
             .isEqualTo(1);
+    }
+
+    @Test
+    void testQueryForLongIsZeroWhenCollectionIsMissing() {
+        assertThat(new CountCollectionByNameStatement("missingCollection").queryForLong(database))
+                .isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/liquibase/ext/mongodb/statement/ListCollectionNamesStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/ListCollectionNamesStatementIT.java
@@ -1,0 +1,78 @@
+package liquibase.ext.mongodb.statement;
+
+/*-
+ * #%L
+ * Liquibase MongoDB Extension
+ * %%
+ * Copyright (C) 2019 Mastercard
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import liquibase.ext.AbstractMongoIntegrationTest;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static liquibase.ext.mongodb.TestUtils.COLLECTION_NAME_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListCollectionNamesStatementIT extends AbstractMongoIntegrationTest {
+
+    private String collectionName;
+
+    @BeforeEach
+    public void createCollectionName() {
+        collectionName = COLLECTION_NAME_1 + System.nanoTime();
+    }
+
+    @Test
+    void testCanListAllCollections() {
+        final int numberOfCollections = 25;
+        IntStream.rangeClosed(1, numberOfCollections)
+                .forEach(indx -> mongoDatabase.createCollection(collectionName + indx));
+
+        List<String> collectionNames = new ListCollectionNamesStatement().queryForList(database);
+        assertThat(collectionNames.size())
+                .isEqualTo(numberOfCollections);
+    }
+
+    @Test
+    void testCanListCollectionsMatchingFilter() {
+
+        mongoDatabase.createCollection(collectionName);
+        mongoDatabase.createCollection(collectionName+"other");
+
+        Document filter = new Document("name", collectionName);
+        List<String> collectionNames = new ListCollectionNamesStatement(filter).queryForList(database);
+        assertThat(collectionNames.size())
+                .isEqualTo(1);
+        assertThat(collectionNames).contains(collectionName);
+    }
+
+    @Test
+    void toStringJs() {
+        String expected = String.format("db.runCommand({'listCollections': 1, 'filter': {'name': '%s'}});", collectionName)
+                .replaceAll("'","\"");
+        Document filter = new Document("name", collectionName);
+        ListCollectionNamesStatement statement = new ListCollectionNamesStatement(filter);
+
+        assertThat(statement.toString())
+                .isEqualTo(statement.toJs())
+                .isEqualTo(expected);
+    }
+}

--- a/src/test/java/liquibase/ext/mongodb/statement/ListCollectionNamesStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/ListCollectionNamesStatementIT.java
@@ -4,7 +4,7 @@ package liquibase.ext.mongodb.statement;
  * #%L
  * Liquibase MongoDB Extension
  * %%
- * Copyright (C) 2019 Mastercard
+ * Copyright (C) 2021 Mastercard
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -41,35 +41,36 @@ class ListCollectionNamesStatementIT extends AbstractMongoIntegrationTest {
     }
 
     @Test
-    void testCanListAllCollections() {
+    void testListAllCollections() {
         final int numberOfCollections = 25;
         IntStream.rangeClosed(1, numberOfCollections)
                 .forEach(indx -> mongoDatabase.createCollection(collectionName + indx));
 
-        List<String> collectionNames = new ListCollectionNamesStatement().queryForList(database);
-        assertThat(collectionNames.size())
-                .isEqualTo(numberOfCollections);
+        final List<String> collectionNames = new ListCollectionNamesStatement().queryForList(database);
+        assertThat(collectionNames)
+                .isNotNull()
+                .hasSize(numberOfCollections);
     }
 
     @Test
-    void testCanListCollectionsMatchingFilter() {
+    void testListCollectionsMatchingFilter() {
 
         mongoDatabase.createCollection(collectionName);
-        mongoDatabase.createCollection(collectionName+"other");
+        mongoDatabase.createCollection(collectionName + "other");
 
-        Document filter = new Document("name", collectionName);
-        List<String> collectionNames = new ListCollectionNamesStatement(filter).queryForList(database);
-        assertThat(collectionNames.size())
-                .isEqualTo(1);
-        assertThat(collectionNames).contains(collectionName);
+        final Document filter = new Document("name", collectionName);
+        final List<String> collectionNames = new ListCollectionNamesStatement(filter).queryForList(database);
+        assertThat(collectionNames)
+                .hasSize(1)
+                .containsExactly(collectionName);
     }
 
     @Test
     void toStringJs() {
-        String expected = String.format("db.runCommand({'listCollections': 1, 'filter': {'name': '%s'}});", collectionName)
-                .replaceAll("'","\"");
-        Document filter = new Document("name", collectionName);
-        ListCollectionNamesStatement statement = new ListCollectionNamesStatement(filter);
+        final String expected = "db.runCommand({\"listCollections\": 1, \"filter\": {\"name\": \"" + collectionName + "\"}, \"authorizedCollections\": true, \"nameOnly\": true});";
+
+        final Document filter = new Document("name", collectionName);
+        final ListCollectionNamesStatement statement = new ListCollectionNamesStatement(filter);
 
         assertThat(statement.toString())
                 .isEqualTo(statement.toJs())


### PR DESCRIPTION
introduce `ListCollectionNamesStatement` (as a `runCommand` statement) to be used by


* `CountCollectionByNameStatement`
* `DropAllCollectionsStatement`

Edited  `DropCollectionStatement` to support options ( as per https://docs.mongodb.com/manual/reference/command/drop/ )

┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1272) by [Unito](https://www.unito.io/learn-more)
