### PR TITLE
Run databasechangelock update with upsert "true" only the first time.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <jupiter.surefire.version>1.3.2</jupiter.surefire.version>
         <mockito-core.version>4.5.1</mockito-core.version>
         <mockito-junit-jupiter.version>4.5.1</mockito-junit-jupiter.version>
-        <mongodb-driver.version>4.3.4</mongodb-driver.version>
+        <mongodb-driver.version>4.6.0</mongodb-driver.version>
         <!--mongodb-driver.version>3.12.7</mongodb-driver.version-->
         <lombok.version>1.18.24</lombok.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
Run databasechangelock update with upsert "true" only the first time.
This works in MongoDb and is needed in Azure CosmoDb's MongoDB Api.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2163) by [Unito](https://www.unito.io)
