### PR TITLE
Fix GitHub URL in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </issueManagement>
     <scm>
         <connection>scm:git:http://github.com/liquibase/liquibase-mongodb.git</connection>
-        <url>https://github.com/liquibase/liquibase-monbodb</url>
+        <url>https://github.com/liquibase/liquibase-mongodb</url>
         <tag>HEAD</tag>
     </scm>
     <developers>


### PR DESCRIPTION
It's a detail but that makes the links provided by Dependabot incorrect.