### PR TITLE
DocumentDB Issue

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -74,7 +74,8 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
      * Check the response and throw an appropriate exception if the command was not successful
      */
     protected void checkResponse(final Document responseDocument) throws MongoException {
-        final Double ok = responseDocument.getDouble(OK);
+        final Double ok = responseDocument.get(OK) instanceof Integer ? (double) responseDocument.getInteger(OK) :
+                responseDocument.getDouble(OK);
         final List<Document> writeErrors = responseDocument.getList(WRITE_ERRORS, Document.class);
 
         if (nonNull(ok) && !ok.equals(1.0d)


### PR DESCRIPTION
The `ResponseDocument` we get back from DocumentDB emulating MongoDB 4.0 during a migration has an attribute, `ok` which is an `Integer`. 

Additionally, DocumentDB does not support document validation, so: something along the lines of `System.setProperty("liquibase.mongodb.supportsValidator", "false");` will be necessary

This addresses the issue described in https://github.com/liquibase/liquibase-mongodb/issues/244 