### PR TITLE
DAT-15071 Automatically bump version on mongodb via the release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,6 +38,10 @@ jobs:
           echo "Saw Liquibase version ${{ steps.collect-data.outputs.liquibaseVersion }}"
           echo "Saw Extension version ${{ steps.collect-data.outputs.extensionVersion }}"
 
+  update-version:
+    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
+    secrets: inherit
+
   build:
     name: "Build and Test"
     runs-on: ubuntu-latest
@@ -62,11 +66,6 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
 
-      - name: Configure git user
-        run: |
-          git config user.name "liquibot"
-          git config user.email "liquibot@liquibase.org"
-
       - name: Download and install liquibase-core.jar
         uses: dsaltares/fetch-gh-release-asset@master
         with:
@@ -78,24 +77,6 @@ jobs:
 
       - name: Install liquibase-core.jar
         run: mvn -B org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file -Dfile=liquibase-core.jar
-
-      - name: Update pom.xml with release versions and commit changes
-        run: |
-          mvn -B versions:set -DnewVersion=${{ needs.setup.outputs.extensionVersion }} -DallowSnapshots=false -DoldVersion="*"
-          mvn -B versions:use-dep-version -Dincludes=org.liquibase:liquibase-core -DdepVersion=${{ needs.setup.outputs.liquibaseVersion }} -DforceVersion=true
-
-          git add pom.xml
-          if git diff-index --cached --quiet HEAD --
-          then
-            echo "Nothing new to commit"
-          else
-            git commit -m "Version Bumped to ${{ needs.setup.outputs.extensionVersion }}"
-          fi
-          git tag -a -m "Version Bumped to ${{ needs.setup.outputs.extensionVersion }}" liquibase-mongodb-${{ needs.setup.outputs.extensionVersion }}
-          git push "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - name: Get release SHA
         id: get-release-sha

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,10 +38,6 @@ jobs:
           echo "Saw Liquibase version ${{ steps.collect-data.outputs.liquibaseVersion }}"
           echo "Saw Extension version ${{ steps.collect-data.outputs.extensionVersion }}"
 
-  update-version:
-    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
-    secrets: inherit
-
   build:
     name: "Build and Test"
     runs-on: ubuntu-latest
@@ -124,8 +120,12 @@ jobs:
       - name: Test With Maven
         run: mvn clean verify -Prun-its --file pom.xml
 
+  update-version:
+    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
+    secrets: inherit
+
   draft-release:
-    needs: [ setup, build, integration-tests ]
+    needs: [ setup, build, integration-tests, update-version ]
     name: Draft Release
     runs-on: ubuntu-latest
     steps:
@@ -147,34 +147,3 @@ jobs:
           files: liquibase-mongodb-*.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  bump-pom-to-snapshot:
-    name: Prepare POM for Development
-    runs-on: ubuntu-latest
-    needs: [ draft-release ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-
-      - name: Configure git user
-        run: |
-          git config user.name "liquibot"
-          git config user.email "liquibot@liquibase.org"
-
-      - name: Prepare code for next version
-        run: |
-          git pull
-          mvn -B versions:set -DnextSnapshot=true
-          git add pom.xml
-          git commit -m "Version Bumped to Snapshot for Development"
-          git push "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,6 +38,13 @@ jobs:
           echo "Saw Liquibase version ${{ steps.collect-data.outputs.liquibaseVersion }}"
           echo "Saw Extension version ${{ steps.collect-data.outputs.extensionVersion }}"
 
+  release-prepare:
+    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
+    with:
+      perform-release: false
+      perform-rollback: false
+    secrets: inherit
+
   build:
     name: "Build and Test"
     runs-on: ubuntu-latest
@@ -120,12 +127,8 @@ jobs:
       - name: Test With Maven
         run: mvn clean verify -Prun-its --file pom.xml
 
-  update-version:
-    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
-    secrets: inherit
-
   draft-release:
-    needs: [ setup, build, integration-tests, update-version ]
+    needs: [ setup, build, integration-tests, release-prepare ]
     name: Draft Release
     runs-on: ubuntu-latest
     steps:
@@ -147,3 +150,21 @@ jobs:
           files: liquibase-mongodb-*.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-perform:
+    needs: [ setup, release-prepare, build, integration-tests, draft-release ]
+    if: ${{ success() }}
+    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
+    with:
+      perform-release: true
+      perform-rollback: false
+    secrets: inherit
+
+  release-rollback:
+    needs: [ setup, release-prepare, build, integration-tests, draft-release ]
+    if: ${{ failure() }}
+    uses: liquibase/build-logic/.github/workflows/extension-update-version.yml@v0.3.2
+    with:
+      perform-release: false
+      perform-rollback: true
+    secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,14 @@
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+                <configuration>
+                    <scmCommentPrefix>[Version Bumped to ${project.version}]</scmCommentPrefix>
+                </configuration>
+            </plugin>
         </plugins>
 
     </build>


### PR DESCRIPTION
More details here: https://github.com/liquibase/build-logic/pull/32

feat(create-release.yml): add update-version job to update extension version before building
refactor(create-release.yml): remove git user configuration and pom.xml version update from build job and move it to update-version job
feat(pom.xml): add maven-release-plugin to configure scmCommentPrefix for version bumping commit messages