### PR TITLE
[DAT-15373] Fix checksum empty spaces validation

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/change/AbstractMongoChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/AbstractMongoChange.java
@@ -20,9 +20,20 @@ package liquibase.ext.mongodb.change;
  * #L%
  */
 
+import liquibase.ChecksumVersion;
+import liquibase.GlobalConfiguration;
+import liquibase.Scope;
 import liquibase.change.AbstractChange;
+import liquibase.change.AbstractSQLChange;
+import liquibase.change.CheckSum;
 import liquibase.database.Database;
+import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.ext.mongodb.database.MongoLiquibaseDatabase;
+import liquibase.util.StringUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 public abstract class AbstractMongoChange extends AbstractChange {
 
@@ -39,5 +50,28 @@ public abstract class AbstractMongoChange extends AbstractChange {
     @Override
     public boolean generateRollbackStatementsVolatile(final Database database) {
         return false;
+    }
+
+    /**
+     * Generate checksum normalizing texts so changes as adding white spaces and new lines
+     * won't break the checksum
+     */
+    CheckSum generateCheckSum(String... texts) {
+        ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
+            return super.generateCheckSum();
+        }
+
+        String text = "";
+        if (texts != null) {
+            StringUtil.join(texts, "");
+        }
+
+
+        try (InputStream stream = new ByteArrayInputStream(text.getBytes(GlobalConfiguration.FILE_ENCODING.getCurrentValue()))) {
+            return CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false);
+        } catch (IOException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/AbstractMongoChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/AbstractMongoChange.java
@@ -64,7 +64,7 @@ public abstract class AbstractMongoChange extends AbstractChange {
 
         String text = "";
         if (texts != null) {
-            StringUtil.join(texts, "");
+            text = StringUtil.join(texts, "");
         }
 
 

--- a/src/main/java/liquibase/ext/mongodb/change/AdminCommandChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/AdminCommandChange.java
@@ -21,6 +21,7 @@ package liquibase.ext.mongodb.change;
  */
 
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.AdminCommandStatement;
@@ -51,5 +52,10 @@ public class AdminCommandChange extends AbstractMongoChange {
         return new SqlStatement[]{
             new AdminCommandStatement(command)
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(command);
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/CreateCollectionChange.java
@@ -22,6 +22,7 @@ package liquibase.ext.mongodb.change;
 
 import liquibase.change.Change;
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.CreateCollectionStatement;
@@ -63,5 +64,10 @@ public class CreateCollectionChange extends AbstractMongoChange {
         return new Change[]{
                 inverse
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(collectionName, options);
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/CreateIndexChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/CreateIndexChange.java
@@ -22,6 +22,7 @@ package liquibase.ext.mongodb.change;
 
 import liquibase.change.Change;
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.CreateIndexStatement;
@@ -64,6 +65,11 @@ public class CreateIndexChange extends AbstractMongoChange {
         return new Change[]{
                 inverse
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(collectionName, keys, options);
     }
 
 }

--- a/src/main/java/liquibase/ext/mongodb/change/DropIndexChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/DropIndexChange.java
@@ -21,6 +21,7 @@ package liquibase.ext.mongodb.change;
  */
 
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.DropIndexStatement;
@@ -51,6 +52,11 @@ public class DropIndexChange extends AbstractMongoChange {
         return new SqlStatement[]{
                 new DropIndexStatement(collectionName, keys)
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(collectionName, keys);
     }
 
 }

--- a/src/main/java/liquibase/ext/mongodb/change/InsertManyChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/InsertManyChange.java
@@ -21,6 +21,7 @@ package liquibase.ext.mongodb.change;
  */
 
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.InsertManyStatement;
@@ -53,5 +54,10 @@ public class InsertManyChange extends AbstractMongoChange {
         return new SqlStatement[]{
                 new InsertManyStatement(collectionName, documents, options)
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(collectionName, documents, options);
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/InsertOneChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/InsertOneChange.java
@@ -21,6 +21,7 @@ package liquibase.ext.mongodb.change;
  */
 
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.InsertOneStatement;
@@ -52,5 +53,10 @@ public class InsertOneChange extends AbstractMongoChange {
         return new SqlStatement[]{
                 new InsertOneStatement(collectionName, document, options)
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(collectionName, document, options);
     }
 }

--- a/src/main/java/liquibase/ext/mongodb/change/RunCommandChange.java
+++ b/src/main/java/liquibase/ext/mongodb/change/RunCommandChange.java
@@ -21,6 +21,7 @@ package liquibase.ext.mongodb.change;
  */
 
 import liquibase.change.ChangeMetaData;
+import liquibase.change.CheckSum;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.ext.mongodb.statement.RunCommandStatement;
@@ -51,5 +52,10 @@ public class RunCommandChange extends AbstractMongoChange {
         return new SqlStatement[]{
             new RunCommandStatement(command)
         };
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return super.generateCheckSum(command);
     }
 }

--- a/src/test/java/liquibase/ext/MongoLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/MongoLiquibaseIT.java
@@ -253,16 +253,16 @@ class MongoLiquibaseIT extends AbstractMongoIntegrationTest {
         assertThat(changeSets).hasSize(10)
                 .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getExecType, MongoRanChangeSet::getLastCheckSum)
                 .containsExactly(
-                        tuple("1", 1, SKIPPED, CheckSum.parse("9:dad21c5e3cce72d50076657128081c0c")),
-                        tuple("2", 2, EXECUTED, CheckSum.parse("9:67e9ce155c04ef70eb553ff6cab13f58")),
-                        tuple("3", 3, EXECUTED, CheckSum.parse("9:9bf4925aac3718c3eb1929e95b5332c9")),
-                        tuple("4", 4, SKIPPED, CheckSum.parse("9:d37e34334465cfae484bbe8e3e6f1482")),
-                        tuple("5", 5, EXECUTED, CheckSum.parse("9:b8ef52e2f9d7b96664577c026bc079e4")),
-                        tuple("6", 6, EXECUTED, CheckSum.parse("9:2e1e5f512aaab73117ca23108ec8076f")),
-                        tuple("7", 7, SKIPPED, CheckSum.parse("9:5e1fca21679293232bbade890e057bca")),
-                        tuple("8", 8, EXECUTED, CheckSum.parse("9:b95cec9546c91ae40c4ce63f7901ad24")),
-                        tuple("9", 9, EXECUTED, CheckSum.parse("9:ae8941a239134f17455b01f0d92ff53b")),
-                        tuple("10", 10, SKIPPED, CheckSum.parse("9:89b8c6b5f63ad239e2993c84d24ad342"))
+                        tuple("1", 1, SKIPPED, CheckSum.parse("9:af9b299cda217428f9d082b71472c7c2")),
+                        tuple("2", 2, EXECUTED, CheckSum.parse("9:dea86a555a8faa2df648fc3d5b0a26ab")),
+                        tuple("3", 3, EXECUTED, CheckSum.parse("9:ff63cd85bae75ff9e0e2ad0a5c0fcfbb")),
+                        tuple("4", 4, SKIPPED, CheckSum.parse("9:ca49926fc39cda00c50129a8913ae9d6")),
+                        tuple("5", 5, EXECUTED, CheckSum.parse("9:2faf448db2581b8c55d525c099c73386")),
+                        tuple("6", 6, EXECUTED, CheckSum.parse("9:8b8761856542aa6d6794d7bd177a3426")),
+                        tuple("7", 7, SKIPPED, CheckSum.parse("9:a6ad2c0fa2dc8baf57bd109bad14daeb")),
+                        tuple("8", 8, EXECUTED, CheckSum.parse("9:fbb6bb7c3c51c5a4f1c8b5a1b87a1815")),
+                        tuple("9", 9, EXECUTED, CheckSum.parse("9:cb4e4e196d3181666e273cbbc5fa6472")),
+                        tuple("10", 10, SKIPPED, CheckSum.parse("9:7e2e9cf0382c328297856300dcb391eb"))
                 );
 
         assertThat(getCollections(connection))

--- a/src/test/java/liquibase/ext/MongoLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/MongoLiquibaseIT.java
@@ -78,9 +78,9 @@ class MongoLiquibaseIT extends AbstractMongoIntegrationTest {
         assertThat(changeSets).hasSize(3)
                 .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getLastCheckSum)
                 .containsExactly(
-                        tuple("1", 1, CheckSum.parse("9:66f74bbe4c1ae2aeec30a60885135611")),
-                        tuple("2", 2, CheckSum.parse("9:8da4d127bd90a85116dfd6109a527ab2")),
-                        tuple("3", 3, CheckSum.parse("9:ab691099a5db5a4ec05af5a310af1c40")));
+                        tuple("1", 1, CheckSum.parse("9:6123e9daaa6ae11900e17fb620e90bcb")),
+                        tuple("2", 2, CheckSum.parse("9:2c6879e9e003d28d5aecfcf68e5a841a")),
+                        tuple("3", 3, CheckSum.parse("9:ab7ee385b3e94d5d3050daba4c719f08")));
 
         // Clear checksums
         liquibase.clearCheckSums();
@@ -99,9 +99,9 @@ class MongoLiquibaseIT extends AbstractMongoIntegrationTest {
         assertThat(changeSets).hasSize(3)
                 .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getLastCheckSum)
                 .containsExactly(
-                        tuple("1", 1, CheckSum.parse("9:66f74bbe4c1ae2aeec30a60885135611")),
-                        tuple("2", 2, CheckSum.parse("9:8da4d127bd90a85116dfd6109a527ab2")),
-                        tuple("3", 3, CheckSum.parse("9:ab691099a5db5a4ec05af5a310af1c40")));
+                        tuple("1", 1, CheckSum.parse("9:6123e9daaa6ae11900e17fb620e90bcb")),
+                        tuple("2", 2, CheckSum.parse("9:2c6879e9e003d28d5aecfcf68e5a841a")),
+                        tuple("3", 3, CheckSum.parse("9:ab7ee385b3e94d5d3050daba4c719f08")));
     }
 
     @SneakyThrows

--- a/src/test/java/liquibase/ext/MongoLiquibaseJsonIT.java
+++ b/src/test/java/liquibase/ext/MongoLiquibaseJsonIT.java
@@ -68,7 +68,7 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
                 .filteredOn(c -> c.getId().equals("1")).hasSize(1).first()
                 .returns("liquibase/ext/json/generic-1-insert-people.json", RanChangeSet::getChangeLog)
                 .returns("Alex", RanChangeSet::getAuthor)
-                .returns(CheckSum.parse("9:26cdcf268d7947186164df2b3e5691d7"), RanChangeSet::getLastCheckSum)
+                .returns(CheckSum.parse("9:95727cf24d16eda63ee7e0ca62f9e713"), RanChangeSet::getLastCheckSum)
                 .returns(true, c -> nonNull(c.getDateExecuted()))
                 .returns(null, RanChangeSet::getTag)
                 .returns(ChangeSet.ExecType.EXECUTED, RanChangeSet::getExecType)
@@ -84,7 +84,7 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
                 .filteredOn(c -> c.getId().equals("2")).hasSize(1).first()
                 .returns("liquibase/ext/json/generic-1-insert-people.json", RanChangeSet::getChangeLog)
                 .returns("Nick", RanChangeSet::getAuthor)
-                .returns(CheckSum.parse("9:3a5250595e3b5a2f373b0d05212894bb"), RanChangeSet::getLastCheckSum)
+                .returns(CheckSum.parse("9:9eb024092590f9c802032847573771af"), RanChangeSet::getLastCheckSum)
                 .returns(true, c -> nonNull(c.getDateExecuted()))
                 .returns(null, RanChangeSet::getTag)
                 .returns(ChangeSet.ExecType.EXECUTED, RanChangeSet::getExecType)
@@ -108,7 +108,7 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
                 .filteredOn(c -> c.getId().equals("1")).hasSize(1).first()
                 .returns("liquibase/ext/json/generic-1-insert-people.json", RanChangeSet::getChangeLog)
                 .returns("Alex", RanChangeSet::getAuthor)
-                .returns(CheckSum.parse("9:26cdcf268d7947186164df2b3e5691d7"), RanChangeSet::getLastCheckSum)
+                .returns(CheckSum.parse("9:95727cf24d16eda63ee7e0ca62f9e713"), RanChangeSet::getLastCheckSum)
                 .returns(true, c -> nonNull(c.getDateExecuted()))
                 .returns(null, RanChangeSet::getTag)
                 .returns(ChangeSet.ExecType.EXECUTED, RanChangeSet::getExecType)
@@ -124,7 +124,7 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
                 .filteredOn(c -> c.getId().equals("2")).hasSize(1).first()
                 .returns("liquibase/ext/json/generic-1-insert-people.json", RanChangeSet::getChangeLog)
                 .returns("Nick", RanChangeSet::getAuthor)
-                .returns(CheckSum.parse("9:3a5250595e3b5a2f373b0d05212894bb"), RanChangeSet::getLastCheckSum)
+                .returns(CheckSum.parse("9:9eb024092590f9c802032847573771af"), RanChangeSet::getLastCheckSum)
                 .returns(true, c -> nonNull(c.getDateExecuted()))
                 .returns(null, RanChangeSet::getTag)
                 .returns(ChangeSet.ExecType.EXECUTED, RanChangeSet::getExecType)
@@ -147,8 +147,8 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
         assertThat(changeSets).hasSize(2)
                 .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getLastCheckSum)
                 .containsExactly(
-                        tuple("1", 1, CheckSum.parse("9:26cdcf268d7947186164df2b3e5691d7")),
-                        tuple("2", 2, CheckSum.parse("9:3a5250595e3b5a2f373b0d05212894bb")));
+                        tuple("1", 1, CheckSum.parse("9:95727cf24d16eda63ee7e0ca62f9e713")),
+                        tuple("2", 2, CheckSum.parse("9:9eb024092590f9c802032847573771af")));
 
         List<Document> documents = new FindAllStatement("person").queryForList(database);
         assertThat(documents).hasSize(3)
@@ -166,8 +166,8 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
         assertThat(changeSets).hasSize(4)
                 .extracting(MongoRanChangeSet::getId, MongoRanChangeSet::getOrderExecuted, MongoRanChangeSet::getLastCheckSum)
                 .containsExactly(
-                        tuple("1", 1, CheckSum.parse("9:26cdcf268d7947186164df2b3e5691d7")),
-                        tuple("2", 2, CheckSum.parse("9:3a5250595e3b5a2f373b0d05212894bb")),
+                        tuple("1", 1, CheckSum.parse("9:95727cf24d16eda63ee7e0ca62f9e713")),
+                        tuple("2", 2, CheckSum.parse("9:9eb024092590f9c802032847573771af")),
                         tuple("1", 3, CheckSum.parse("9:bfb744c23f97ee4bd9df050d189efa08")),
                         tuple("2", 4, CheckSum.parse("9:ac7ea4fec237f17c4ae15a7a5ab1c7f0")));
 

--- a/src/test/java/liquibase/ext/MongoLiquibaseJsonIT.java
+++ b/src/test/java/liquibase/ext/MongoLiquibaseJsonIT.java
@@ -168,8 +168,8 @@ class MongoLiquibaseJsonIT extends AbstractMongoIntegrationTest {
                 .containsExactly(
                         tuple("1", 1, CheckSum.parse("9:95727cf24d16eda63ee7e0ca62f9e713")),
                         tuple("2", 2, CheckSum.parse("9:9eb024092590f9c802032847573771af")),
-                        tuple("1", 3, CheckSum.parse("9:bfb744c23f97ee4bd9df050d189efa08")),
-                        tuple("2", 4, CheckSum.parse("9:ac7ea4fec237f17c4ae15a7a5ab1c7f0")));
+                        tuple("1", 3, CheckSum.parse("9:d9b8155bf8f6d6ddcb3e3887bfae7331")),
+                        tuple("2", 4, CheckSum.parse("9:4825273a230884cbcd35ff658f4b261d")));
 
         documents = new FindAllStatement("person").queryForList(database);
         assertThat(documents).hasSize(2)

--- a/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
@@ -48,8 +48,8 @@ class AdminCommandChangeTest extends AbstractMongoChangeTest {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.admin-command.test.xml", database);
         assertThat(changeSets).hasSize(2).extracting(ChangeSet::getAuthor, ChangeSet::getId, changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()))
                 .containsExactly(
-                        tuple("alex", "1", CheckSum.parse("9:589527b47d13e0034c4860bbe0a742e6")),
-                        tuple("alex", "2", CheckSum.parse("9:1140b6605ecab8cf5cc6032bacc70f4b"))
+                        tuple("alex", "1", CheckSum.parse("9:2a659bf380005d42308e0616959f69c1")),
+                        tuple("alex", "2", CheckSum.parse("9:ee7e537588408b8f31eac5532fd80f2b"))
                 );
 
         assertThat(changeSets.get(0).getChanges())

--- a/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
@@ -48,8 +48,8 @@ class AdminCommandChangeTest extends AbstractMongoChangeTest {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.admin-command.test.xml", database);
         assertThat(changeSets).hasSize(2).extracting(ChangeSet::getAuthor, ChangeSet::getId, changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()))
                 .containsExactly(
-                        tuple("alex", "1", CheckSum.parse("9:589527b47d13e0034c4860bbe0a742e6")),
-                        tuple("alex", "2", CheckSum.parse("9:1140b6605ecab8cf5cc6032bacc70f4b"))
+                        tuple("alex", "1", CheckSum.parse("9:f01deb4f054d9620e0ddc9a1cfbdf6c9")),
+                        tuple("alex", "2", CheckSum.parse("9:f01deb4f054d9620e0ddc9a1cfbdf6c9"))
                 );
 
         assertThat(changeSets.get(0).getChanges())

--- a/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/AdminCommandChangeTest.java
@@ -48,8 +48,8 @@ class AdminCommandChangeTest extends AbstractMongoChangeTest {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.admin-command.test.xml", database);
         assertThat(changeSets).hasSize(2).extracting(ChangeSet::getAuthor, ChangeSet::getId, changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()))
                 .containsExactly(
-                        tuple("alex", "1", CheckSum.parse("9:f01deb4f054d9620e0ddc9a1cfbdf6c9")),
-                        tuple("alex", "2", CheckSum.parse("9:f01deb4f054d9620e0ddc9a1cfbdf6c9"))
+                        tuple("alex", "1", CheckSum.parse("9:589527b47d13e0034c4860bbe0a742e6")),
+                        tuple("alex", "2", CheckSum.parse("9:1140b6605ecab8cf5cc6032bacc70f4b"))
                 );
 
         assertThat(changeSets.get(0).getChanges())

--- a/src/test/java/liquibase/ext/mongodb/change/CreateCollectionChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateCollectionChangeTest.java
@@ -62,7 +62,7 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
                 .isNotNull()
                 .hasSize(1)
                 .first()
-                .returns("9:ea079a06e3fa4c4559b7a186382d9dde", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
+                .returns("9:c20f49290372ce7d93cb3dad5b7d84e4", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
 
         assertThat(changeSets.get(0).getChanges())
                 .hasSize(3)

--- a/src/test/java/liquibase/ext/mongodb/change/CreateCollectionChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateCollectionChangeTest.java
@@ -62,7 +62,7 @@ class CreateCollectionChangeTest extends AbstractMongoChangeTest {
                 .isNotNull()
                 .hasSize(1)
                 .first()
-                .returns("9:ada06701e2890846393245c7b45d11b9", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
+                .returns("9:ea079a06e3fa4c4559b7a186382d9dde", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
 
         assertThat(changeSets.get(0).getChanges())
                 .hasSize(3)

--- a/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
@@ -51,7 +51,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "collection1")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", null)
-                .returns(CheckSum.parse("9:e6b1630ad2b20ef41a69eee853528099"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
                 .returns("Index created for collection collection1", Change::getConfirmationMessage)
                 .returns(true, c -> c.supportsRollback(database));
 
@@ -80,7 +80,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.create-index.test.xml", database);
 
         assertThat(changeSets).hasSize(1).first()
-                .returns("9:75e8da1118c4312c5987ecf9eb47a09e", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
+                .returns("9:c2dd6504fe11325573b8015c9057e907", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
 
         final List<Change> changes1 = changeSets.get(0).getChanges();
         assertThat(changes1).hasSize(2);

--- a/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
@@ -90,7 +90,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "createIndexTest")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", "{unique: true, name: \"ui_tppClientId\"}")
-                .returns(CheckSum.parse("9:2ea778164e5507ea6678158bee3f8959"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
                 .returns(true, c -> c.supportsRollback(database));
 
         assertThat(Arrays.asList(changes1.get(0).generateStatements(database))).hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
@@ -115,7 +115,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "createIndexNoOptionsTest")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", null)
-                .returns(CheckSum.parse("9:4499e67ade10db858b5eafa32665623f"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
                 .returns(true, c -> c.supportsRollback(database));
 
         assertThat(Arrays.asList(changes1.get(1).generateStatements(database))).hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
@@ -51,7 +51,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "collection1")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", null)
-                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:39414d63d912421a93152b03017c2d49"), Change::generateCheckSum)
                 .returns("Index created for collection collection1", Change::getConfirmationMessage)
                 .returns(true, c -> c.supportsRollback(database));
 
@@ -90,7 +90,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "createIndexTest")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", "{unique: true, name: \"ui_tppClientId\"}")
-                .returns(CheckSum.parse("9:39414d63d912421a93152b03017c2d49"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:540ed5fb8583e2e9b9b58c72cd923647"), Change::generateCheckSum)
                 .returns(true, c -> c.supportsRollback(database));
 
         assertThat(Arrays.asList(changes1.get(0).generateStatements(database))).hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
@@ -80,7 +80,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
         final List<ChangeSet> changeSets = getChangesets("liquibase/ext/changelog.create-index.test.xml", database);
 
         assertThat(changeSets).hasSize(1).first()
-                .returns("9:c2dd6504fe11325573b8015c9057e907", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
+                .returns("9:73c08fccf08f1802915156fe638b7d53", changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
 
         final List<Change> changes1 = changeSets.get(0).getChanges();
         assertThat(changes1).hasSize(2);
@@ -90,7 +90,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "createIndexTest")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", "{unique: true, name: \"ui_tppClientId\"}")
-                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:39414d63d912421a93152b03017c2d49"), Change::generateCheckSum)
                 .returns(true, c -> c.supportsRollback(database));
 
         assertThat(Arrays.asList(changes1.get(0).generateStatements(database))).hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/CreateIndexChangeTest.java
@@ -115,7 +115,7 @@ class CreateIndexChangeTest extends AbstractMongoChangeTest {
                 .hasFieldOrPropertyWithValue("CollectionName", "createIndexNoOptionsTest")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
                 .hasFieldOrPropertyWithValue("options", null)
-                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:1f9cabae6442a9aa4ab0e9cdf4181a66"), Change::generateCheckSum)
                 .returns(true, c -> c.supportsRollback(database));
 
         assertThat(Arrays.asList(changes1.get(1).generateStatements(database))).hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/DropIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/DropIndexChangeTest.java
@@ -44,7 +44,7 @@ class DropIndexChangeTest extends AbstractMongoChangeTest {
         assertThat(dropIndexChange)
                 .hasFieldOrPropertyWithValue("CollectionName", "collection1")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
-                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:bc13eacab67f94f078248d07af32838a"), Change::generateCheckSum)
                 .returns("Index dropped for collection collection1", Change::getConfirmationMessage)
                 .returns(false, c -> c.supportsRollback(database));
 

--- a/src/test/java/liquibase/ext/mongodb/change/DropIndexChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/DropIndexChangeTest.java
@@ -44,7 +44,7 @@ class DropIndexChangeTest extends AbstractMongoChangeTest {
         assertThat(dropIndexChange)
                 .hasFieldOrPropertyWithValue("CollectionName", "collection1")
                 .hasFieldOrPropertyWithValue("keys", "{ clientId: 1, type: 1}")
-                .returns(CheckSum.parse("9:016c274fba45cb1313dccf7866797235"), Change::generateCheckSum)
+                .returns(CheckSum.parse("9:d41d8cd98f00b204e9800998ecf8427e"), Change::generateCheckSum)
                 .returns("Index dropped for collection collection1", Change::getConfirmationMessage)
                 .returns(false, c -> c.supportsRollback(database));
 

--- a/src/test/java/liquibase/ext/mongodb/change/InsertManyChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertManyChangeTest.java
@@ -46,7 +46,7 @@ class InsertManyChangeTest extends AbstractMongoChangeTest {
 
         assertThat(changeSets)
                 .hasSize(1).first()
-                .returns("9:ae462af55d2b62a1c0898f356c614249",  changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
+                .returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9",  changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
 
         assertThat(changeSets.get(0).getChanges())
                 .hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/InsertManyChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertManyChangeTest.java
@@ -46,7 +46,7 @@ class InsertManyChangeTest extends AbstractMongoChangeTest {
 
         assertThat(changeSets)
                 .hasSize(1).first()
-                .returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9",  changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
+                .returns("9:ff86bb7a77e760a728ad7c0df4e83137",  changeSet -> changeSet.generateCheckSum(ChecksumVersion.latest()).toString());
 
         assertThat(changeSets.get(0).getChanges())
                 .hasSize(1)

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -61,7 +61,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasFieldOrPropertyWithValue("document", "{\n                id: 111\n                }")
             .hasFieldOrPropertyWithValue("options", null);
 
-        assertThat(changeSets.get(1)).returns("9:c2dd6504fe11325573b8015c9057e907",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(1)).returns("9:2c6879e9e003d28d5aecfcf68e5a841a",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(1).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest2")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 2\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -72,7 +72,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasFieldOrPropertyWithValue("document", "{\n                id: 3\n                }")
             .hasFieldOrPropertyWithValue("options", null);
 
-        assertThat(changeSets.get(2)).returns("9:ab691099a5db5a4ec05af5a310af1c40",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(2)).returns("9:c2dd6504fe11325573b8015c9057e907",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(2).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest2")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 21323123\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -61,7 +61,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasFieldOrPropertyWithValue("document", "{\n                id: 111\n                }")
             .hasFieldOrPropertyWithValue("options", null);
 
-        assertThat(changeSets.get(1)).returns("9:8da4d127bd90a85116dfd6109a527ab2",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(1)).returns("9:c2dd6504fe11325573b8015c9057e907",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(1).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest2")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 2\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -55,7 +55,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasSize(2)
             .hasOnlyElementsOfType(InsertOneChange.class);
 
-        assertThat(changeSets.get(0)).returns("9:66f74bbe4c1ae2aeec30a60885135611", s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(0)).returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9", s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(0).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest1")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 111\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -72,7 +72,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasFieldOrPropertyWithValue("document", "{\n                id: 3\n                }")
             .hasFieldOrPropertyWithValue("options", null);
 
-        assertThat(changeSets.get(2)).returns("9:c2dd6504fe11325573b8015c9057e907",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(2)).returns("9:ab7ee385b3e94d5d3050daba4c719f08",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(2).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest2")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 21323123\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/InsertOneChangeTest.java
@@ -55,7 +55,7 @@ class InsertOneChangeTest extends AbstractMongoChangeTest {
             .hasSize(2)
             .hasOnlyElementsOfType(InsertOneChange.class);
 
-        assertThat(changeSets.get(0)).returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9", s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(0)).returns("9:6123e9daaa6ae11900e17fb620e90bcb", s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(0).getChanges().get(0))
             .hasFieldOrPropertyWithValue("collectionName", "insertOneTest1")
             .hasFieldOrPropertyWithValue("document", "{\n                id: 111\n                }")

--- a/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
@@ -61,7 +61,7 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
         assertThat(sqlStatements).hasOnlyElementsOfType(RunCommandStatement.class);
         assertThat(((RunCommandStatement) sqlStatements[0]).getCommand()).containsEntry("buildInfo", 1);
 
-        assertThat(changeSets.get(1)).returns("9:589527b47d13e0034c4860bbe0a742e6",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(1)).returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(1).getChanges()).hasSize(1);
         assertThat(changeSets.get(1).getChanges()).hasOnlyElementsOfTypes(AdminCommandChange.class);
 

--- a/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
@@ -48,7 +48,7 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
 
         assertThat(changeSets).hasSize(2);
 
-        assertThat(changeSets.get(0)).returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(0)).returns("9:2a659bf380005d42308e0616959f69c1",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
 
         assertThat(changeSets.get(0).getChanges()).hasSize(1);
         assertThat(changeSets.get(0).getChanges()).hasOnlyElementsOfTypes(RunCommandChange.class);

--- a/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
@@ -61,7 +61,7 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
         assertThat(sqlStatements).hasOnlyElementsOfType(RunCommandStatement.class);
         assertThat(((RunCommandStatement) sqlStatements[0]).getCommand()).containsEntry("buildInfo", 1);
 
-        assertThat(changeSets.get(1)).returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(1)).returns("9:2a659bf380005d42308e0616959f69c1",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
         assertThat(changeSets.get(1).getChanges()).hasSize(1);
         assertThat(changeSets.get(1).getChanges()).hasOnlyElementsOfTypes(AdminCommandChange.class);
 

--- a/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
+++ b/src/test/java/liquibase/ext/mongodb/change/RunCommandChangeTest.java
@@ -48,7 +48,7 @@ class RunCommandChangeTest extends AbstractMongoChangeTest {
 
         assertThat(changeSets).hasSize(2);
 
-        assertThat(changeSets.get(0)).returns("9:3115eba1af85f6636cf281fa54ec5c1d",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
+        assertThat(changeSets.get(0)).returns("9:f01deb4f054d9620e0ddc9a1cfbdf6c9",  s -> s.generateCheckSum(ChecksumVersion.latest()).toString());
 
         assertThat(changeSets.get(0).getChanges()).hasSize(1);
         assertThat(changeSets.get(0).getChanges()).hasOnlyElementsOfTypes(RunCommandChange.class);

--- a/src/test/java/liquibase/ext/mongodb/changelog/MongoHistoryServiceIT.java
+++ b/src/test/java/liquibase/ext/mongodb/changelog/MongoHistoryServiceIT.java
@@ -183,7 +183,7 @@ class MongoHistoryServiceIT extends AbstractMongoIntegrationTest {
         changeSet2.addChange(createCollectionChange1);
         changeSet2.addChange(createCollectionChange2);
         assertThat(changeSet2.generateCheckSum(ChecksumVersion.latest()))
-                .hasToString("9:e23be10b8382f379139f7f07617aa6ff");
+                .hasToString("9:c6b62cb517b0bc6cde17be8f75b2c1e2");
 
         historyService.replaceChecksum(changeSet2);
 
@@ -195,7 +195,7 @@ class MongoHistoryServiceIT extends AbstractMongoIntegrationTest {
 
         assertThat(ranChangeSets).hasSize(2).filteredOn("id", "2").first()
                 .returns("2", RanChangeSet::getId)
-                .returns(CheckSum.parse("9:e23be10b8382f379139f7f07617aa6ff"), RanChangeSet::getLastCheckSum)
+                .returns(CheckSum.parse("9:c6b62cb517b0bc6cde17be8f75b2c1e2"), RanChangeSet::getLastCheckSum)
                 .returns(changeSet2.generateCheckSum(ChecksumVersion.V9), RanChangeSet::getLastCheckSum);
 
         assertThat(historyService.isServiceInitialized()).isFalse();


### PR DESCRIPTION
Generate checksum normalizing texts so changes as adding white spaces and new lines won't break the checksum, making Mongodb extensions compliant with core changes.

Built upon DAT-15279