### PR TITLE
Set application name in MongDB driver config

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/database/MongoClientDriver.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoClientDriver.java
@@ -3,6 +3,8 @@ package liquibase.ext.mongodb.database;
 import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoClientSettings.Builder;
 import liquibase.Scope;
 import liquibase.exception.DatabaseException;
 import liquibase.util.StringUtil;
@@ -23,8 +25,14 @@ public class MongoClientDriver implements Driver {
 
     public MongoClient connect(final ConnectionString connectionString) throws DatabaseException {
         final MongoClient client;
+
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .applicationName("Liquibase")
+                .build();
+
         try {
-            client = MongoClients.create(connectionString);
+            client = MongoClients.create(settings);
         } catch (final Exception e) {
             throw new DatabaseException("Connection could not be established to: "
                     + connectionString.getConnectionString(), e);


### PR DESCRIPTION
With this change, it's possible to see connections coming from Liquibase in the MongoDB log files.

There are no changes in functionality nor in how the MongoDB driver connects to MongoDB. This change is only about providing some extra metadata to make it easy to audit when connections to a cluster are coming from a Liquibase run.