### PR TITLE
changed `extension-attach-artifact-release` version from 0.7.8 to main

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
     secrets: inherit


### PR DESCRIPTION
https://github.com/liquibase/liquibase-mongodb/actions/runs/10991845947/job/30515024465 failed with ```Error: This request has been automatically failed because it uses a deprecated version of `actions/download-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/```