### PR TITLE
Fix ReplaceChangeLogLockStatement

### DIFF
--- a/src/test/java/liquibase/ext/mongodb/lockservice/ReplaceChangeLogLockStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/lockservice/ReplaceChangeLogLockStatementIT.java
@@ -1,0 +1,98 @@
+package liquibase.ext.mongodb.lockservice;
+
+/*-
+ * #%L
+ * Liquibase MongoDB Extension
+ * %%
+ * Copyright (C) 2019 Mastercard
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import liquibase.ext.AbstractMongoIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReplaceChangeLogLockStatementIT extends AbstractMongoIntegrationTest {
+
+    private static final String LOCK_COLLECTION_NAME = "lockCollection";
+
+    @Test
+    void lock() {
+        final ReplaceChangeLogLockStatement lockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, true);
+
+        assertThat(lockStatement.update(database)).isOne();
+    }
+
+    @Test
+    void multipleLock() {
+        final ReplaceChangeLogLockStatement lockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, true);
+
+        lockStatement.update(database);
+
+        assertThat(lockStatement.update(database)).isZero();
+    }
+
+    @Test
+    void unlock() {
+        final ReplaceChangeLogLockStatement unlockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, false);
+
+        assertThat(unlockStatement.update(database)).isOne();
+    }
+
+    @Test
+    void lockThenUnlock() {
+        final ReplaceChangeLogLockStatement lockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, true);
+        final ReplaceChangeLogLockStatement unlockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, false);
+
+        lockStatement.update(database);
+
+        assertThat(unlockStatement.update(database)).isOne();
+    }
+
+    @Test
+    void lockThenUnlockByDifferentHost() {
+        final ReplaceChangeLogLockStatement lockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, true);
+        final ReplaceChangeLogLockStatement unlockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, false);
+
+        System.setProperty("liquibase.hostDescription", "lockHost");
+        lockStatement.update(database);
+        System.setProperty("liquibase.hostDescription", "unlockHost");
+
+        assertThat(unlockStatement.update(database)).isZero();
+    }
+
+    @Test
+    void unlockThenLock() {
+        final ReplaceChangeLogLockStatement unlockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, false);
+        final ReplaceChangeLogLockStatement lockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, true);
+
+        unlockStatement.update(database);
+
+        assertThat(lockStatement.update(database)).isOne();
+    }
+
+    @Test
+    void unlockThenLockByDifferentHost() {
+        final ReplaceChangeLogLockStatement unlockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, false);
+        final ReplaceChangeLogLockStatement lockStatement = new ReplaceChangeLogLockStatement(LOCK_COLLECTION_NAME, true);
+
+        System.setProperty("liquibase.hostDescription", "unlockHost");
+        unlockStatement.update(database);
+        System.setProperty("liquibase.hostDescription", "lockHost");
+
+        assertThat(lockStatement.update(database)).isOne();
+    }
+}

--- a/src/test/java/liquibase/ext/mongodb/lockservice/ReplaceChangeLogLockStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/lockservice/ReplaceChangeLogLockStatementIT.java
@@ -1,25 +1,5 @@
 package liquibase.ext.mongodb.lockservice;
 
-/*-
- * #%L
- * Liquibase MongoDB Extension
- * %%
- * Copyright (C) 2019 Mastercard
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
-
 import liquibase.ext.AbstractMongoIntegrationTest;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
The current `update` method of `ReplaceChangeLogLockStatement` is not safe. It allows multiple owner (identified by the `lockedBy` field) to acquire the lock simultaneously. And it also allows the release by a different owner. There isn't any fence in the current implementation:
https://github.com/liquibase/liquibase-mongodb/blob/5582bcd6450364608872bd6dd21d03a482f4cda7/src/main/java/liquibase/ext/mongodb/lockservice/ReplaceChangeLogLockStatement.java#L77-L84

Indeed, by running the following code with the latest liquibase-mongodb version there will be also multiple exceptions:
```java
public final class Main {
    public static void main(final String[] args) throws Exception {
        for (var i = 0; i < 16; i++) {
            Executors.newSingleThreadExecutor().execute(() ->
                    {
                        try (
                                var db = DatabaseFactory.getInstance().openDatabase(
                                        "mongodb://localhost:27017/test?directConnection=true",
                                        null,
                                        null,
                                        null,
                                        null
                                );
                                var liquibase = new Liquibase(
                                        "db/changelog.xml",
                                        new ClassLoaderResourceAccessor(),
                                        db
                                )
                        ) {
                            liquibase.update("");
                        } catch (Exception e) {
                            throw new RuntimeException(e);
                        }
                    }
            );
        }
        Thread.sleep(10000);
    }
}
```
 
The proposed implementation blocks multiple acquisition by taking advantage of the Mongo DuplicateKey error. Specifically, an owner will try to acquire only an unlocked lock. And we have multiple scenarios here:
1. It finds the unlocked lock and it acquires the lock by replacing the Mongo document
2. It doesn't find the lock because this is the first acquisition request ever. So, it acquires the lock by inserting the Mongo document
3. It doesn't find the lock because it's already locked. In this case, it will try in any case to insert the document in Mongo but this time it will fail to acquire because the DuplicateKey error

The same approach is used to allow the lock release only by his owner.