### PR TITLE
DAT-18810: app naming updated, it contains now versions of core/pro liquibase and extension version also.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>json</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>3.9.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
             <artifactId>json</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>3.9.9</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/liquibase/ext/mongodb/database/MongoClientDriver.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoClientDriver.java
@@ -12,18 +12,12 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
-import java.util.Enumeration;
 import java.util.Properties;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 import java.util.logging.Logger;
 
 public class MongoClientDriver implements Driver {
@@ -52,24 +46,21 @@ public class MongoClientDriver implements Driver {
     }
 
     private String getFullApplicationName() {
-        try {
+        try (FileReader fileReader = new FileReader("pom.xml")){
             MavenXpp3Reader reader = new MavenXpp3Reader();
-            Model model = reader.read(new FileReader("pom.xml"));
+            Model model = reader.read(fileReader);
 
             boolean isCommercial = model.getArtifactId().contains("commercial");
             String buildVersion = LiquibaseUtil.getBuildVersion();
             String extVersion = model.getVersion();
             String appType = isCommercial ? "PRO" : "OSS";
             String extType = isCommercial ? "ProExt" : "OssExt";
-            URL url = Scope.getCurrentScope().getClassLoader().getResource("META-INF/MANIFEST.MF");
-            Manifest manifest = new Manifest(url.openStream());
-            Attributes attr = manifest.getMainAttributes();
 
             return String.join("_", "Liquibase", appType, buildVersion, extType, extVersion);
         } catch (XmlPullParserException | IOException e) {
             Scope.getCurrentScope().getLog(this.getClass()).warning("Failed to extract application full name for current connection.");
         }
-        return "";
+        return "Liquibase";
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
@@ -164,6 +164,9 @@ public class MongoConnection extends AbstractNoSqlConnection {
     }
 
     protected String getAppName(Properties driverProperties, boolean isProExt) {
+        if(driverProperties == null) {
+            return "Liquibase";
+        }
         if(driverProperties.getProperty("appName") != null) {
             return driverProperties.getProperty("appName");
         }

--- a/src/test/java/liquibase/ext/mongodb/database/MongoConnectionTest.java
+++ b/src/test/java/liquibase/ext/mongodb/database/MongoConnectionTest.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -81,7 +82,7 @@ class MongoConnectionTest {
     @Test
     void getConnectionUserName() {
 
-        when(driverMock.connect(any(ConnectionString.class))).thenReturn(clientMock);
+        when(driverMock.connect(any(ConnectionString.class), anyString())).thenReturn(clientMock);
         when(clientMock.getDatabase(any())).thenReturn(databaseMock);
 
         assertThat(connection.getConnectionUserName()).isEmpty();
@@ -97,7 +98,7 @@ class MongoConnectionTest {
     @Test
     void isClosed() {
 
-        when(driverMock.connect(any(ConnectionString.class))).thenReturn(clientMock);
+        when(driverMock.connect(any(ConnectionString.class), anyString())).thenReturn(clientMock);
         when(clientMock.getDatabase(any())).thenReturn(databaseMock);
 
         assertThat(connection.isClosed()).isTrue();
@@ -116,7 +117,7 @@ class MongoConnectionTest {
     @SneakyThrows
     @Test
     void getCatalog() {
-        when(driverMock.connect(any(ConnectionString.class))).thenReturn(clientMock);
+        when(driverMock.connect(any(ConnectionString.class), anyString())).thenReturn(clientMock);
         when(clientMock.getDatabase(any())).thenReturn(databaseMock);
         when(databaseMock.getName()).thenReturn("test_db");
         when(databaseMock.withCodecRegistry(any())).thenReturn(databaseMock);
@@ -136,7 +137,7 @@ class MongoConnectionTest {
     @SneakyThrows
     @Test
     void open() {
-        when(driverMock.connect(any(ConnectionString.class))).thenReturn(clientMock);
+        when(driverMock.connect(any(ConnectionString.class), anyString())).thenReturn(clientMock);
         when(clientMock.getDatabase(any())).thenReturn(databaseMock);
         when(databaseMock.withCodecRegistry(any())).thenReturn(databaseMock);
 
@@ -147,7 +148,7 @@ class MongoConnectionTest {
         assertThat(connection.getConnectionUserName()).isEmpty();
         assertThat(connection.getURL()).isEqualTo("localhost:27017");
 
-        verify(driverMock).connect(any(ConnectionString.class));
+        verify(driverMock).connect(any(ConnectionString.class), anyString());
         verify(clientMock).getDatabase(any());
         verify(databaseMock).withCodecRegistry(any());
         verifyNoMoreInteractions(driverMock, clientMock, databaseMock);
@@ -161,7 +162,7 @@ class MongoConnectionTest {
         assertThat(connection.getConnectionUserName()).isEqualTo("user1");
         assertThat(connection.getURL()).isEqualTo("localhost:27017");
 
-        verify(driverMock, times(2)).connect(any(ConnectionString.class));
+        verify(driverMock, times(2)).connect(any(ConnectionString.class), anyString());
         verify(clientMock, times(2)).getDatabase(any());
         verify(databaseMock, times(2)).withCodecRegistry(any());
         verifyNoMoreInteractions(driverMock, clientMock, databaseMock);
@@ -178,7 +179,7 @@ class MongoConnectionTest {
         assertThat(connection.getConnectionUserName()).isEqualTo("user2");
         assertThat(connection.getURL()).isEqualTo("mongodb1.example.com:27317,mongodb2.example.com:27017");
 
-        verify(driverMock, times(3)).connect(any(ConnectionString.class));
+        verify(driverMock, times(3)).connect(any(ConnectionString.class), anyString());
         verify(clientMock, times(3)).getDatabase(any());
         verify(databaseMock, times(3)).withCodecRegistry(any());
         verifyNoMoreInteractions(driverMock, clientMock, databaseMock);
@@ -194,7 +195,7 @@ class MongoConnectionTest {
         assertThat(connection.getConnectionUserName()).isEqualTo("user3");
         assertThat(connection.getURL()).isEqualTo("localhost:27017");
 
-        verify(driverMock, times(4)).connect(any(ConnectionString.class));
+        verify(driverMock, times(4)).connect(any(ConnectionString.class), anyString());
         verify(clientMock, times(4)).getDatabase(any());
         verify(databaseMock, times(4)).withCodecRegistry(any());
         verifyNoMoreInteractions(driverMock, clientMock, databaseMock);


### PR DESCRIPTION
Tested on Built Jar-s with different core and pro JAR-s stored in `liquibase/lib`.

Only OSS Jar is present:
<img width="930" alt="Screenshot 2025-01-30 at 16 25 20" src="https://github.com/user-attachments/assets/08de4658-dee7-4103-8fff-1492a493730e" />

Commercial Jar is present and Pro license is valid:
<img width="1104" alt="Screenshot 2025-01-30 at 15 32 31" src="https://github.com/user-attachments/assets/6a9f5d22-0ffe-4d0d-b9dd-07a52b11ad79" />
