### PR TITLE
Fix rows affected reporting for MongoDB operations

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -84,13 +84,13 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
      * Check the response and throw an appropriate exception if the command was not successful
      */
     protected void checkResponse(final Document responseDocument) throws MongoException {
-        final Double ok = responseDocument.get(OK) instanceof Integer
+        final double ok = responseDocument.get(OK) instanceof Integer
                 ? (double) responseDocument.getInteger(OK)
                 : responseDocument.getDouble(OK);
 
         final List<Document> writeErrors = responseDocument.getList(WRITE_ERRORS, Document.class);
 
-        if (!ok.equals(1.0d) || nonNull(writeErrors) && !writeErrors.isEmpty()) {
+        if (ok != 1.0d || nonNull(writeErrors) && !writeErrors.isEmpty()) {
             throw new MongoException("Command failed. The full response is " + responseDocument.toJson());
         }
     }

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -106,7 +106,7 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
             scopeRowsAffected = NoSqlExecutor.GLOBAL_ROWS_AFFECTED;
         }
         Boolean shouldUpdate = Scope.getCurrentScope().get(SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, Boolean.TRUE);
-        if (scopeRowsAffected != null && Boolean.TRUE.equals(shouldUpdate)) {
+        if (Boolean.TRUE.equals(shouldUpdate)) {
             scopeRowsAffected.addAndGet(affectedCount);
             Scope.getCurrentScope().getLog(getClass()).fine("Added " + affectedCount + " to ROWS_AFFECTED_SCOPE_KEY; new total=" + scopeRowsAffected.get());
         }

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -125,10 +125,10 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
             return 0;
         }
 
-        // For insert operations
-        Integer nInserted = response.getInteger(N);
-        if (nInserted != null) {
-            return nInserted;
+        // For all operations that return 'n'
+        Integer n = response.getInteger(N);
+        if (n != null) {
+            return n;
         }
 
         // For update operations
@@ -141,20 +141,6 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
         Integer nRemoved = response.getInteger(N_REMOVED);
         if (nRemoved != null) {
             return nRemoved;
-        }
-
-        // For generic operations
-        Integer n = response.getInteger(N);
-        if (n != null) {
-            return n;
-        }
-
-        // Default successful operation count
-        double ok = response.get(OK) instanceof Integer ?
-                (double) response.getInteger(OK) :
-                response.getDouble(OK);
-        if (ok == 1.0d) {
-            return 1;
         }
 
         return 0;

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -116,10 +116,10 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
     protected int extractAffectedCount(Document response) {
         // For collection-level operations
         if (isCollectionOperation()) {
-            Double ok = response.get(OK) instanceof Integer ?
+            double ok = response.get(OK) instanceof Integer ?
                     (double) response.getInteger(OK) :
                     response.getDouble(OK);
-            if (ok.equals(1.0d)) {
+            if (ok == 1.0d) {
                 return 1;
             }
             return 0;
@@ -150,10 +150,10 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
         }
 
         // Default successful operation count
-        Double ok = response.get(OK) instanceof Integer ?
+        double ok = response.get(OK) instanceof Integer ?
                 (double) response.getInteger(OK) :
                 response.getDouble(OK);
-        if (ok.equals(1.0d)) {
+        if (ok == 1.0d) {
             return 1;
         }
 

--- a/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
+++ b/src/main/java/liquibase/ext/mongodb/statement/AbstractRunCommandStatement.java
@@ -90,8 +90,7 @@ public abstract class AbstractRunCommandStatement extends AbstractMongoStatement
 
         final List<Document> writeErrors = responseDocument.getList(WRITE_ERRORS, Document.class);
 
-        if ((nonNull(ok) && !ok.equals(1.0d))
-                || (nonNull(writeErrors) && !writeErrors.isEmpty())) {
+        if (!ok.equals(1.0d) || nonNull(writeErrors) && !writeErrors.isEmpty()) {
             throw new MongoException("Command failed. The full response is " + responseDocument.toJson());
         }
     }

--- a/src/main/java/liquibase/nosql/executor/NoSqlExecutor.java
+++ b/src/main/java/liquibase/nosql/executor/NoSqlExecutor.java
@@ -184,7 +184,7 @@ public class NoSqlExecutor extends AbstractExecutor {
     @Override
     public void execute(final SqlStatement sql) throws DatabaseException {
         Map<String, Object> scopeValues = new HashMap<>();
-        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, new AtomicInteger(0));
+        scopeValues.putIfAbsent(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, new AtomicInteger(0));
         scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
 
         try {

--- a/src/test/java/liquibase/ext/mongodb/statement/RowsAffectedStatementIT.java
+++ b/src/test/java/liquibase/ext/mongodb/statement/RowsAffectedStatementIT.java
@@ -1,0 +1,146 @@
+package liquibase.ext.mongodb.statement;
+
+import liquibase.Scope;
+import liquibase.executor.jvm.JdbcExecutor;
+import liquibase.ext.AbstractMongoIntegrationTest;
+import lombok.SneakyThrows;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static liquibase.ext.mongodb.TestUtils.COLLECTION_NAME_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RowsAffectedStatementIT extends AbstractMongoIntegrationTest {
+
+    private String collectionName;
+    private AtomicInteger rowsAffected;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        collectionName = COLLECTION_NAME_1 + System.nanoTime();
+        rowsAffected = new AtomicInteger(0);
+
+        // Setup scope with rowsAffected counter
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        // The test methods will run within this scope
+        Scope.child(scopeValues, () -> {
+            super.setUpEach();
+            collectionName = COLLECTION_NAME_1 + System.nanoTime();
+        });
+    }
+
+    @Override
+    @SneakyThrows
+    protected void tearDownEach() {
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        Scope.child(scopeValues, () -> {
+            executor.execute(new DropAllCollectionsStatement());
+            connection.close();
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldTrackRowsAffectedForCreateCollection() {
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        Scope.child(scopeValues, () -> {
+            final CreateCollectionStatement createStatement = new CreateCollectionStatement(collectionName);
+            createStatement.execute(database);
+            assertThat(rowsAffected.get()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldTrackRowsAffectedForInsertOne() {
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        Scope.child(scopeValues, () -> {
+            final CreateCollectionStatement createStatement = new CreateCollectionStatement(collectionName);
+            createStatement.execute(database);
+            rowsAffected.set(0);
+
+            Document doc = new Document("test", "value");
+            final InsertOneStatement insertStatement = new InsertOneStatement(collectionName, doc);
+            insertStatement.execute(database);
+
+            assertThat(rowsAffected.get()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldTrackRowsAffectedForInsertMany() {
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        Scope.child(scopeValues, () -> {
+            final CreateCollectionStatement createStatement = new CreateCollectionStatement(collectionName);
+            createStatement.execute(database);
+            rowsAffected.set(0);
+
+            Document doc1 = new Document("test", "value1");
+            Document doc2 = new Document("test", "value2");
+            final InsertManyStatement insertStatement = new InsertManyStatement(collectionName, Arrays.asList(doc1, doc2));
+            insertStatement.execute(database);
+
+            assertThat(rowsAffected.get()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldTrackRowsAffectedForDropCollection() {
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        Scope.child(scopeValues, () -> {
+            final CreateCollectionStatement createStatement = new CreateCollectionStatement(collectionName);
+            createStatement.execute(database);
+            rowsAffected.set(0);
+
+            final DropCollectionStatement dropStatement = new DropCollectionStatement(collectionName);
+            dropStatement.execute(database);
+
+            assertThat(rowsAffected.get()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldTrackTotalRowsAffectedForMultipleOperations() {
+        Map<String, Object> scopeValues = new HashMap<>();
+        scopeValues.put(JdbcExecutor.ROWS_AFFECTED_SCOPE_KEY, rowsAffected);
+        scopeValues.put(JdbcExecutor.SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY, true);
+
+        Scope.child(scopeValues, () -> {
+            final CreateCollectionStatement createStatement = new CreateCollectionStatement(collectionName);
+            createStatement.execute(database);
+
+            Document doc1 = new Document("test", "value1");
+            Document doc2 = new Document("test", "value2");
+            final InsertManyStatement insertStatement = new InsertManyStatement(collectionName, Arrays.asList(doc1, doc2));
+            insertStatement.execute(database);
+            assertThat(rowsAffected.get()).isEqualTo(3); // 1 to create + 2 to insert
+        });
+    }
+}


### PR DESCRIPTION
## Overview
This PR addresses the issue where rows affected are incorrectly shown as -1 in the update summary for MongoDB operations. It implements proper tracking of affected documents for various MongoDB commands including collection operations and document manipulations.

## Changes
- Added document count tracking in AbstractRunCommandStatement
- Implemented rows affected extraction from MongoDB command responses
- Added support for different operation types (insert, update, delete, collection ops)
- Updated NoSqlExecutor to properly handle rows affected scope

## Testing
Added new integration tests (RowsAffectedStatementIT) covering:
- Collection creation/deletion
- Single document insertion
- Multiple document insertion
- Combined operations

Result: 

![Screenshot 2025-02-21 at 03 43 34](https://github.com/user-attachments/assets/dc9a06f4-ba79-4c00-9b38-9dce97f078e1)

