### PR TITLE
DAT-19561: added necessary changes for snapshot higher hierarchy objects enabling

### DIFF
--- a/src/main/java/liquibase/nosql/snapshot/NoSqlSnapshotGenerator.java
+++ b/src/main/java/liquibase/nosql/snapshot/NoSqlSnapshotGenerator.java
@@ -50,9 +50,7 @@ public abstract class NoSqlSnapshotGenerator implements SnapshotGenerator {
             if (addsTo() != null) {
                 for (Class<? extends DatabaseObject> addType : addsTo()) {
                     if (addType.isAssignableFrom(example.getClass())) {
-                        if (chainResponse != null) {
-                            addTo(chainResponse, snapshot);
-                        }
+                        addTo(chainResponse, snapshot);
                     }
                 }
             }

--- a/src/main/java/liquibase/nosql/snapshot/NoSqlSnapshotGenerator.java
+++ b/src/main/java/liquibase/nosql/snapshot/NoSqlSnapshotGenerator.java
@@ -46,7 +46,7 @@ public abstract class NoSqlSnapshotGenerator implements SnapshotGenerator {
             return null;
         }
 
-        if (shouldAddTo(example.getClass(), snapshot)) {
+        if (shouldAddTo(snapshot)) {
             if (addsTo() != null) {
                 for (Class<? extends DatabaseObject> addType : addsTo()) {
                     if (addType.isAssignableFrom(example.getClass())) {
@@ -58,7 +58,7 @@ public abstract class NoSqlSnapshotGenerator implements SnapshotGenerator {
         return chainResponse;
     }
 
-    protected boolean shouldAddTo(Class<? extends DatabaseObject> databaseObjectType, DatabaseSnapshot snapshot) {
+    protected boolean shouldAddTo(DatabaseSnapshot snapshot) {
         return (defaultFor != null) && snapshot.getSnapshotControl().shouldInclude(defaultFor);
     }
 

--- a/src/main/resources/META-INF/services/liquibase.snapshot.SnapshotGenerator
+++ b/src/main/resources/META-INF/services/liquibase.snapshot.SnapshotGenerator
@@ -1,1 +1,0 @@
-liquibase.nosql.snapshot.NoSqlSnapshotGenerator


### PR DESCRIPTION
No more needed. We changed architecture for mongo-commercial, these changes no more needed. See related PR https://github.com/liquibase/liquibase-commercial-mongodb/pull/308