### PR TITLE
✨ DAT19697

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'main'
 
-      jobs:
+jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
@@ -29,7 +29,7 @@ on:
           timestamp=`(date +'%Y-%m-%d %H:%M:%S %Z')`
           echo "timeStamp=${timestamp}" >> $GITHUB_OUTPUT
 
-build-and-publish:
+  build-and-publish:
     name: Build & Publish
     runs-on: ubuntu-22.04
     needs: setup

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,0 +1,63 @@
+name: Build Main/Master SNAPSHOT
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+      jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-22.04
+    outputs:
+      timeStamp: ${{ steps.get-timestamp.outputs.timeStamp }}
+      latestMergeSha: ${{ steps.get-sha.outputs.latestMergeSha }}
+      setupSuccessful: "true"
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Latest Merge Commit SHA
+        id: get-sha
+        run: |
+          latest_merge_sha=`(git rev-parse --short HEAD)`
+          echo "latestMergeSha=${latest_merge_sha}" >> $GITHUB_OUTPUT
+
+      - name: Get Timestamp
+        id: get-timestamp
+        run: |
+          timestamp=`(date +'%Y-%m-%d %H:%M:%S %Z')`
+          echo "timeStamp=${timestamp}" >> $GITHUB_OUTPUT
+
+build-and-publish:
+    name: Build & Publish
+    runs-on: ubuntu-22.04
+    needs: setup
+    permissions:
+      contents: read
+      packages: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java for publishing to GitHub Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: liquibase
+
+        # Publish master-SNAPSHOT version to GPM
+      - name: Version Artifact as master-SNAPSHOT
+        run: ./mvnw versions:set "-DnewVersion=master-SNAPSHOT"
+
+      - name: Publish master-SNAPSHOT
+        run: ./mvnw -B clean deploy -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase-mongodb" "-Dbuild.branch=master" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+
+        # Publish <commitsha>-SNAPSHOT version to GPM
+      - name: Version Artifact as commit-SNAPSHOT
+        run: ./mvnw versions:set -DnewVersion="${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT"
+
+      - name: Publish commit-SNAPSHOT
+        run: ./mvnw -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase-mongodb" "-Dbuild.branch=master" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and publishing process for the main/master branch. The workflow includes steps for setting up the environment, obtaining the latest commit SHA and timestamp, and publishing both master-SNAPSHOT and commit-SNAPSHOT versions of the artifact.

Key changes include:

* [`.github/workflows/build-master.yml`](diffhunk://#diff-53f6a76fa86b1994f9da743d84e130a48058a0d0657949c412c203d5f0aedfe8R1-R63): Created a new workflow named "Build Main/Master SNAPSHOT" that triggers on pushes to the main branch and workflow dispatch events.
* Setup job: Added steps to check out the repository, get the latest merge commit SHA, and get the current timestamp.
* Build and publish job: Added steps to set up Java, version the artifact as master-SNAPSHOT, publish the master-SNAPSHOT, version the artifact as commit-SNAPSHOT, and publish the commit-SNAPSHOT.