### PR TITLE
fix lock and history service with closed database connection (DAT-19849)

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/changelog/MongoHistoryService.java
+++ b/src/main/java/liquibase/ext/mongodb/changelog/MongoHistoryService.java
@@ -79,7 +79,7 @@ public class MongoHistoryService extends AbstractNoSqlHistoryService<MongoLiquib
 
     @Override
     public boolean supports(final Database database) {
-        return MongoLiquibaseDatabase.MONGODB_PRODUCT_NAME.equals(database.getDatabaseProductName());
+        return database instanceof MongoLiquibaseDatabase;
     }
 
     @Override

--- a/src/main/java/liquibase/ext/mongodb/lockservice/MongoLockService.java
+++ b/src/main/java/liquibase/ext/mongodb/lockservice/MongoLockService.java
@@ -56,7 +56,7 @@ public class MongoLockService extends AbstractNoSqlLockService<MongoLiquibaseDat
 
     @Override
     public boolean supports(final Database database) {
-        return MongoLiquibaseDatabase.MONGODB_PRODUCT_NAME.equals(database.getDatabaseProductName());
+        return database instanceof MongoLiquibaseDatabase;
     }
 
     @Override


### PR DESCRIPTION
If the database connection has been closed, like would happen when using Oracle with sqlplus and the timeout is exceeded, this call will fail because there is no way to obtain the product name from a closed database connection.