### PR TITLE
DAT-20199   DevOps :: Evaluate GitHub Actions arm64 Hosted Runners in Public Repositories

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@DAT-20199
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -13,14 +13,14 @@ permissions:
 
 jobs:
   nightly-build:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@DAT-20199
     with:
       nightly: true
     secrets: inherit
 
   mongo-atlas-tests:
     name: MongoDB Atlas 8 Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@main
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@DAT-20199
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@DAT-20199
     secrets: inherit

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   dry-run-attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@DAT-20199
     secrets: inherit
     with:
       dry_run: true
@@ -22,7 +22,7 @@ jobs:
 
   dry-run-get-draft-release:
     needs: dry-run-attach-artifact-to-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       dry_run_release_id: ${{ steps.get_draft_release_id.outputs.release_id }}
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   dry-run-release-published:
     needs: dry-run-get-draft-release
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-20199
     secrets: inherit
     with:
       dry_run: true
@@ -63,7 +63,7 @@ jobs:
       deployToMavenCentral: false
 
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: always()
     needs: [dry-run-get-draft-release, dry-run-release-published]
     permissions:
@@ -104,7 +104,7 @@ jobs:
 
   notify:
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs:
       [
         dry-run-attach-artifact-to-release,

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, labeled, unlabeled, synchronize, reopened]
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-20199
     secrets: inherit
     with:
       nameSpace: mongodb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,18 +16,18 @@ on:
 jobs:
   authorize:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - run: true
 
   build-test:
     needs: authorize
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@DAT-20199
     secrets: inherit
 
   integration-tests:
     name: Integration Test - Java ${{ matrix.java }} MongoDB ${{ matrix.mongodb }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       LIQUIBOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
 
   harness-tests:
     name: Harness Tests - Java ${{ matrix.java }} MongoDB ${{ matrix.mongodb }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       LIQUIBOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -196,7 +196,7 @@ jobs:
 
   publish-master-snapshot-to-gpm:
     name: Deploy to GitHub Package Registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build-test
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces significant updates to the GitHub workflows and project configuration files to improve automation, testing, and release processes for the Liquibase MongoDB extension. Key changes include the addition of new workflows for nightly builds, releases, and testing, the removal of the legacy `.travis.yml` configuration, and updates to documentation and badges.

### Workflow Enhancements:
* Added `.github/workflows/build-nightly.yml` for nightly builds, including MongoDB Atlas tests and artifact archiving.
* Introduced `.github/workflows/create-release.yml` and `.github/workflows/release-published.yml` to streamline the release process, including publishing to Sonatype. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R1-R20) [[2]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dR1-R19)
* Added `.github/workflows/dry-run-release.yml` for dry-run release testing, including cleanup steps and Slack notifications for failures.
* Included `.github/workflows/test.yml` for integration and harness tests across multiple Java and MongoDB versions, with support for external contributors.
* Removed legacy `.travis.yml` configuration in favor of GitHub Actions workflows.

### Configuration Updates:
* Updated `.github/release-drafter.yml` to include templates for release notes, categories, and version resolution based on labels.
* Modified `.github/dependabot.yml` to include new labels and remove ignored dependencies.

### Documentation and Badge Updates:
* Updated `README.md` to replace the Travis CI badge with a GitHub Actions badge for nightly builds.
* Added `FerretDB.md` with commands for running Docker Compose and Maven tests.