### PR TITLE
Added override for new DatabaseConnection DAT-20329

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
@@ -132,6 +132,11 @@ public class MongoConnection extends AbstractNoSqlConnection {
     }
 
     @Override
+    public String getVisibleUrl() {
+        return connectionString.getConnectionString();
+    }
+
+    @Override
     public String getConnectionUserName() {
         return ofNullable(this.connectionString).map(ConnectionString::getCredential)
                 .map(MongoCredential::getUserName).orElse("");


### PR DESCRIPTION
****** DO NOT MERGE THIS PR UNTIL LIQUIBASE 4.33 HAS BEEN RELEASED ******

This PR adds an override in MongoConnection of a new getVisibleUrl() method. It returns the connection string. This method will be released as a part of Liquibase 4.33.