### PR TITLE
Added override of DatabaseConnection.getVisibleUrl() method for reporting purposes

### DIFF
--- a/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
@@ -132,6 +132,11 @@ public class MongoConnection extends AbstractNoSqlConnection {
     }
 
     @Override
+    public String getVisibleUrl() {
+        return connectionString.getConnectionString();
+    }
+
+    @Override
     public String getConnectionUserName() {
         return ofNullable(this.connectionString).map(ConnectionString::getCredential)
                 .map(MongoCredential::getUserName).orElse("");

--- a/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
+++ b/src/main/java/liquibase/ext/mongodb/database/MongoConnection.java
@@ -131,7 +131,13 @@ public class MongoConnection extends AbstractNoSqlConnection {
         return String.join(",", ofNullable(this.connectionString).map(ConnectionString::getHosts).orElse(Collections.emptyList()));
     }
 
-    @Override
+    /**
+     *
+     * Return the connection string for display purposes
+     *
+     * @return   String
+     *
+     */
     public String getVisibleUrl() {
         return connectionString.getConnectionString();
     }


### PR DESCRIPTION
This PR adds an override in MongoConnection of a new getVisibleUrl() method. It returns the connection string. This method will be released as a part of Liquibase 4.33.