### PR TITLE
Fix reusable workflow permissions for DAT-20361

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
   actions: read
   packages: write
-
+  id-token: write
 jobs:
   attach-artifact-to-release:
     uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main


### PR DESCRIPTION
- Add missing id-token: write permission to attach-artifact-release.yml to match build-logic/extension-attach-artifact-release.yml

🤖 Generated with [Claude Code](https://claude.ai/code)