### PR TITLE
release: prepare for v5.0.3

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -1,9 +1,13 @@
 name: Attach Artifact to Release
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - closed
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-mongodb</artifactId>
     <packaging>jar</packaging>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.0.3-SNAPSHOT</version>
     <name>Liquibase MongoDB Extension</name>
     <description>Liquibase Extension for MongoDB</description>
     <url>http://www.liquibase.org</url>
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <liquibase.version>5.0.2</liquibase.version>
+        <liquibase.version>5.0.3</liquibase.version>
         <jupiter.surefire.version>1.3.2</jupiter.surefire.version>
         <mockito-core.version>4.11.0</mockito-core.version>
         <mockito-junit-jupiter.version>4.8.0</mockito-junit-jupiter.version>


### PR DESCRIPTION
## Summary

- Bump project version `5.1.0-SNAPSHOT` → `5.0.3-SNAPSHOT`
- Bump `liquibase.version` property `5.0.2` → `5.0.3`
- Add `workflow_dispatch` and `push: main` triggers to `attach-artifact-release.yml` (consistency with bigquery / mssql / cdi / cdi-jakarta)

## Why

mongodb is not in `liquibase/build-logic`'s default `release-extensions` matrix, so the 2026-05-18 v5.0.3 bulk release skipped this repo. The pom was at `5.1.0-SNAPSHOT` (which would have produced a v5.1.0 release), but the rest of the extension family released v5.0.3 today and mongodb users on liquibase-core 5.0.3 need a matching MongoDB extension.

Reverting to the 5.0.x patch line. After merge, the standard release flow fires:

1. `pull_request: closed` on this merge → `attach-artifact-release.yml` runs against fixed build-logic (post `build-logic#593` + `build-logic#594`) → produces `v5.0.3` draft with 16 properly-named assets.
2. Publish the draft → `release-published.yml` deploys to Sonatype / Central Portal.
3. Verify on Maven Central.

The added workflow triggers also make future manual re-runs easier — no need to open a dummy PR if we need to refire the release flow.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, attach-artifact-release produces `v5.0.3` draft with assets named `liquibase-mongodb-5.0.3.<ext>` (16 of them)
- [ ] Publish draft, verify `release-published.yml` succeeds
- [ ] `https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mongodb/5.0.3/` returns 200