### PR TITLE
fix: allow fork pr checkout on actions/checkout v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref_name }}
           persist-credentials: ${{ github.event_name == 'pull_request_target' && 'false' || 'true' }}
+          allow-unsafe-pr-checkout: true
         
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -94,6 +95,7 @@ jobs:
           repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref_name }}
           persist-credentials: ${{ github.event_name == 'pull_request_target' && 'false' || 'true' }}
+          allow-unsafe-pr-checkout: true
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2


### PR DESCRIPTION
actions/checkout v7 refuses to check out fork pull request code from a pull_request_target workflow unless allow-unsafe-pr-checkout is set. This repo moved to v7.0.0 already, so the next external contributor PR would fail at the checkout step. Same fix as liquibase/liquibase#7833.

Only dependabot branches ran test.yml since the v7 bump, and those are internal, which is why nothing failed yet.
