### PR TITLE
release: prepare for v5.0.4 + clear the cached sequence value on reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.liquibase.ext</groupId>
     <artifactId>liquibase-mongodb</artifactId>
     <packaging>jar</packaging>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.0.4-SNAPSHOT</version>
     <name>Liquibase MongoDB Extension</name>
     <description>Liquibase Extension for MongoDB</description>
     <url>http://www.liquibase.org</url>
@@ -23,7 +23,7 @@
     </developers>
 
     <properties>
-        <liquibase.version>5.0.3</liquibase.version>
+        <liquibase.version>5.0.4</liquibase.version>
         <jupiter.surefire.version>1.3.2</jupiter.surefire.version>
         <mockito-core.version>4.11.0</mockito-core.version>
         <mockito-junit-jupiter.version>4.8.0</mockito-junit-jupiter.version>

--- a/src/main/java/liquibase/nosql/changelog/AbstractNoSqlHistoryService.java
+++ b/src/main/java/liquibase/nosql/changelog/AbstractNoSqlHistoryService.java
@@ -108,6 +108,10 @@ public abstract class AbstractNoSqlHistoryService<D extends AbstractNoSqlDatabas
         this.serviceInitialized = false;
         this.hasDatabaseChangeLogTable = null;
         this.adjustedChangeLogTable = FALSE;
+        // Cached MAX(orderExecuted), incremented in memory by getNextSequenceValue() and never
+        // recomputed by init(), so it has to be dropped here or it would survive a reset and hand
+        // out sequence values based on a stale read of the changelog collection.
+        this.lastChangeSetSequenceValue = null;
     }
 
     @Override


### PR DESCRIPTION
Bumps the pom to the 5.0.4 patch line so mongodb matches liquibase-core 5.0.4, and fixes the sequence cache that the bump exposed.

MongoLiquibaseIT.testRollback and testImplicitRollback fail against 5.0.4 in all 12 Java/MongoDB combinations: after a rollback empties the history, the next update numbers orderExecuted 3 and 4 instead of 1 and 2. AbstractNoSqlHistoryService.reset() clears four fields but not lastChangeSetSequenceValue, so the in-memory counter survives the reset.

Until 5.0.3 that was masked, because AbstractUpdateCommandStep.cleanUp() called ChangeLogHistoryServiceFactory.resetAll() after every command and the service was discarded along with its cache. liquibase/liquibase#7909 scoped that cleanup per database so the service now lives across commands. The same PR added this exact line to StandardChangeLogHistoryService.reset() on the core side, so the extension was simply left behind.

The bump and the fix travel together on purpose. With liquibase.version still at 5.0.3 the tests pass with or without the fix, so a separate PR would go green without proving anything.

liquibase-cosmosdb carries a copy of the same file with the same gap, handled separately.
