### PR TITLE
fix(ci): gate integration-tests and harness-tests behind authorize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
 
   integration-tests:
     name: Integration Test - Java ${{ matrix.java }} MongoDB ${{ matrix.mongodb }}
+    needs: authorize
     runs-on: ubuntu-latest
 
     strategy:
@@ -82,6 +83,7 @@ jobs:
 
   harness-tests:
     name: Harness Tests - Java ${{ matrix.java }} MongoDB ${{ matrix.mongodb }}
+    needs: authorize
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Add `needs: authorize` to `integration-tests` and `harness-tests` in `test.yml`, matching `build-test`.
- All jobs that check out PR code now wait for the `authorize` job, so runs from external forks require approval of the `external` environment before any test job starts.

## Verification

- `actionlint .github/workflows/test.yml` passes.
- This PR is internal, so `authorize` resolves to the `internal` environment and the run should proceed without manual approval. The run graph should show the integration and harness jobs downstream of `authorize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)